### PR TITLE
Update dkcli auth and GA endpoint handling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,10 +21,10 @@
 
 ## Key conventions
 
-- For document and answer commands, `DEVELOPERKNOWLEDGE_API_KEY` or `GOOGLE_API_KEY` takes precedence; if neither is set, the CLI falls back to ADC.
+- For Developer Knowledge API commands (`search`, `get`, `batch-get`, and `answer-query`), `DEVELOPERKNOWLEDGE_API_KEY` or `GOOGLE_API_KEY` takes precedence; if neither is set, the CLI falls back to ADC.
 - Local ADC calls need a quota project; the CLI resolves it from `GOOGLE_CLOUD_QUOTA_PROJECT` or `quota_project_id` in the ADC file and sends `x-goog-user-project`.
 - Document names are normalized to `documents/<uri_without_scheme>`; raw paths and full `https://` URLs are both accepted.
 - Search filtering is exposed as the API's AIP-160 `filter` string.
 - Summary/status lines go to stderr; document and answer payloads go to stdout or the file selected with `--output`.
 - Text output always ends with a trailing newline. Frontmatter output includes metadata fields like title, data source, update time, and view when available.
-- User-facing behavior changes should keep `README.md`, `SKILL.md`, and `.agents/skills/dkcli/` docs aligned because the repo ships its own reusable dkcli skill definition there.
+- User-facing behavior changes should keep `README.md` and `SKILL.md` aligned.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,30 @@
+# Repository Instructions
+
+## Build, test, and static checks
+
+- Build: `go build ./...`
+- Test: `go test ./...`
+- Test with race detector: `go test ./... -race`
+- Static checks: `go vet ./...`
+- Single test: `go test ./cmd -run '^TestFetchBatchBisect$'`
+- Single subtest: `go test ./cmd -run '^TestFormatDocWithFrontmatter$/^normal$'`
+
+## High-level architecture
+
+- `main.go` only calls `cmd.Execute()`.
+- `cmd/root.go` centralizes shared HTTP behavior: global output flags, auth selection, rate limiting, retries, and structured output helpers.
+- `search` targets the GA `v1` REST surface.
+- `get` and `batch-get` currently use `v1alpha` as a workaround because the live `v1` methods have been returning `INTERNAL` in direct testing.
+- `answer-query` currently uses `v1alpha` because that is the documented live endpoint.
+- `create-api-key` uses ADC against the API Keys API, then fetches the key string from the follow-up endpoint.
+- Tests live beside the command code in `cmd/` and mostly use `httptest`; `newTestClient` in `cmd/batchget_test.go` is the shared fixture for document API tests.
+
+## Key conventions
+
+- For document and answer commands, `DEVELOPERKNOWLEDGE_API_KEY` or `GOOGLE_API_KEY` takes precedence; if neither is set, the CLI falls back to ADC.
+- Local ADC calls need a quota project; the CLI resolves it from `GOOGLE_CLOUD_QUOTA_PROJECT` or `quota_project_id` in the ADC file and sends `x-goog-user-project`.
+- Document names are normalized to `documents/<uri_without_scheme>`; raw paths and full `https://` URLs are both accepted.
+- Search filtering is exposed as the API's AIP-160 `filter` string.
+- Summary/status lines go to stderr; document and answer payloads go to stdout or the file selected with `--output`.
+- Text output always ends with a trailing newline. Frontmatter output includes metadata fields like title, data source, update time, and view when available.
+- User-facing behavior changes should keep `README.md`, `SKILL.md`, and `.agents/skills/dkcli/` docs aligned because the repo ships its own reusable dkcli skill definition there.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ go install github.com/apstndb/dkcli@latest
 
 ## Authentication
 
-Document retrieval commands prefer an API key when one is configured:
+Developer Knowledge API commands prefer an API key when one is configured, except `create-api-key`:
 
 ```
 export DEVELOPERKNOWLEDGE_API_KEY=<your-key>

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ go install github.com/apstndb/dkcli@latest
 
 ## Authentication
 
-Most commands use an API key. Set one of the following environment variables:
+Document retrieval commands prefer an API key when one is configured:
 
 ```
 export DEVELOPERKNOWLEDGE_API_KEY=<your-key>
@@ -18,11 +18,13 @@ export DEVELOPERKNOWLEDGE_API_KEY=<your-key>
 export GOOGLE_API_KEY=<your-key>
 ```
 
-The `create-api-key` command uses Application Default Credentials instead:
+If neither variable is set, dkcli falls back to an OAuth access token from Application Default Credentials:
 
 ```
 gcloud auth application-default login
 ```
+
+When using local ADC, the Developer Knowledge API also requires a quota project. dkcli reads that from `GOOGLE_CLOUD_QUOTA_PROJECT` or `quota_project_id` in the ADC file. The standard way to set that up is `gcloud auth application-default set-quota-project <project-id>`.
 
 ## Usage
 
@@ -34,19 +36,27 @@ dkcli search "how to create a Cloud Storage bucket"
 # Auto-paging fetches subsequent pages automatically (default max: 5 pages)
 dkcli search -a "Cloud Storage"
 
+# Restrict results to a specific corpus source
+dkcli search --filter 'dataSource = "docs.cloud.google.com"' "BigQuery"
+
 # Fetch more pages
 dkcli search -a --max-pages 20 "Cloud Storage"
 ```
 
 ### Get a document
 
+Currently this uses the `v1alpha` document endpoint as a workaround because the live `v1` `get` method is returning `INTERNAL`.
+
 ```
 dkcli get docs.cloud.google.com/storage/docs/creating-buckets
 # Full URL also works
 dkcli get https://docs.cloud.google.com/storage/docs/creating-buckets
+
 ```
 
 ### Get multiple documents
+
+Currently this uses the `v1alpha` document endpoint as a workaround because the live `v1` `batchGet` method is returning `INTERNAL`.
 
 ```
 dkcli batch-get docs.cloud.google.com/path/to/doc1 docs.cloud.google.com/path/to/doc2
@@ -56,6 +66,7 @@ dkcli batch-get --outdir out docs.cloud.google.com/path/to/doc1 docs.cloud.googl
 
 # With YAML frontmatter
 dkcli batch-get --outdir out --frontmatter docs.cloud.google.com/path/to/doc1
+
 ```
 
 ### Create an API key
@@ -67,6 +78,14 @@ dkcli create-api-key --project my-gcp-project
 # or
 export GOOGLE_CLOUD_PROJECT=my-gcp-project
 dkcli create-api-key
+```
+
+### Answer a grounded query
+
+Uses the `v1alpha:answerQuery` endpoint. It works with an API key, or with ADC if a quota project is available.
+
+```
+dkcli answer-query "How do I create a Cloud Storage bucket?"
 ```
 
 ## Global flags
@@ -87,6 +106,7 @@ dkcli create-api-key
 | `--page-token` | Pagination token from previous response |
 | `--auto-paging`, `-a` | Automatically fetch subsequent pages |
 | `--max-pages` | Max pages to fetch with `--auto-paging` (default: 5, 0 for unlimited) |
+| `--filter` | AIP-160 filter on document metadata |
 
 ### `get`
 
@@ -110,4 +130,4 @@ dkcli create-api-key
 
 ## Rate limiting
 
-The Developer Knowledge API has a 100 RPM quota (Preview). dkcli includes a built-in rate limiter (burst 5, then ~1.67 req/s) and automatic retry with exponential backoff on HTTP 429 responses.
+The Developer Knowledge API has a 100 RPM quota. dkcli includes a built-in rate limiter (burst 5, then ~1.67 req/s) and automatic retry with exponential backoff on HTTP 429 responses.

--- a/SKILL.md
+++ b/SKILL.md
@@ -40,6 +40,7 @@ dkcli can search and retrieve documents from the following domains only.
 
 | Domain | Description |
 |--------|-------------|
+| adk.dev | Agent Development Kit |
 | ai.google.dev | Google AI (Gemini API, etc.) |
 | developer.android.com | Android |
 | developer.chrome.com | Chrome |
@@ -49,8 +50,11 @@ dkcli can search and retrieve documents from the following domains only.
 | docs.apigee.com | Apigee |
 | firebase.google.com | Firebase |
 | fuchsia.dev | Fuchsia OS |
+| go.dev | Go |
 | web.dev | Web development best practices |
 | www.tensorflow.org | TensorFlow |
+
+The corpus excludes language reference pages under `docs.cloud.google.com/*/docs/reference` for C++, .NET, Go, Java, Node.js, PHP, Python, Ruby, and Rust.
 
 If the user asks about documentation outside these domains, dkcli won't help — fall back to other methods.
 
@@ -70,6 +74,12 @@ Use auto-paging (`-a`) when you need broader coverage:
 
 ```bash
 dkcli search -a "BigQuery partitioned tables"
+```
+
+Use `--filter` when you need to stay within a specific data source or time range:
+
+```bash
+dkcli search --filter 'dataSource = "docs.cloud.google.com"' "BigQuery"
 ```
 
 ### Step 2: Get the full document
@@ -114,6 +124,20 @@ For quick inline use without file output:
 dkcli batch-get docs.cloud.google.com/path/to/doc1 docs.cloud.google.com/path/to/doc2
 ```
 
+### Metadata-only retrieval
+
+Search results now also include embedded document metadata under `results[].document` in structured output.
+
+### Grounded answers
+
+For a quick generated answer instead of raw document content, use:
+
+```bash
+dkcli answer-query "How do I create a Cloud Storage bucket?"
+```
+
+This command calls the `v1alpha:answerQuery` endpoint. It works with an API key, or with ADC if a quota project is available.
+
 ## Combining with shell tools
 
 dkcli's structured output formats make it easy to extract exactly what you need:
@@ -148,10 +172,17 @@ dkcli batch-get -f txtar docs.cloud.google.com/doc1 docs.cloud.google.com/doc2  
 
 ## Error handling
 
-If dkcli fails with an API key error (`set DEVELOPERKNOWLEDGE_API_KEY or GOOGLE_API_KEY`), suggest:
+Document commands prefer `DEVELOPERKNOWLEDGE_API_KEY` or `GOOGLE_API_KEY` when either is set. If neither is set, dkcli falls back to ADC.
+
+When using local ADC, the Developer Knowledge API also requires a quota project. dkcli resolves that from `GOOGLE_CLOUD_QUOTA_PROJECT` or `quota_project_id` in the ADC file. The standard way to set that up is `gcloud auth application-default set-quota-project <project-id>`.
+
+If dkcli fails because neither an API key nor ADC is available, suggest:
 
 ```bash
-# Create a key and set it in the current shell (requires gcloud auth application-default login)
+# Option 1: use ADC
+gcloud auth application-default login
+
+# Option 2: create a key and set it in the current shell (requires ADC once)
 export DEVELOPERKNOWLEDGE_API_KEY=$(dkcli create-api-key -p <gcp-project-id> --key-only)
 
 # To persist, append to shell profile
@@ -163,6 +194,8 @@ If the user already has a key, they just need to set the environment variable:
 export DEVELOPERKNOWLEDGE_API_KEY=<key>
 ```
 
+Note: `get` and `batch-get` currently stay on `v1alpha` as a workaround because the live `v1` methods have been returning `INTERNAL` in direct testing, even though the GA docs and proto exist.
+
 ## Command reference
 
 | Command | Purpose |
@@ -171,6 +204,7 @@ export DEVELOPERKNOWLEDGE_API_KEY=<key>
 | `dkcli search -a <query>` | Search with auto-paging |
 | `dkcli get <doc-name>` | Get a full document |
 | `dkcli batch-get <names>...` | Get multiple documents |
+| `dkcli answer-query <query>` | Generate a grounded answer |
 | `dkcli create-api-key --project <id>` | Create a Developer Knowledge API key |
 
 | Useful flags | |
@@ -179,6 +213,7 @@ export DEVELOPERKNOWLEDGE_API_KEY=<key>
 | `-o <file>` | Write to file |
 | `--page-size N` | Results per page for search (max 20) |
 | `--max-pages N` | Max pages with `-a` (default 5) |
+| `--filter <expr>` | Filter search results by document metadata |
 | `--outdir <dir>` | Write each doc to separate files (batch-get) |
 | `--frontmatter` | Prepend YAML frontmatter to text output (get, batch-get) |
 | `--key-only` | Print only the API key string (create-api-key) |

--- a/SKILL.md
+++ b/SKILL.md
@@ -172,7 +172,7 @@ dkcli batch-get -f txtar docs.cloud.google.com/doc1 docs.cloud.google.com/doc2  
 
 ## Error handling
 
-Document commands prefer `DEVELOPERKNOWLEDGE_API_KEY` or `GOOGLE_API_KEY` when either is set. If neither is set, dkcli falls back to ADC.
+Developer Knowledge API commands prefer `DEVELOPERKNOWLEDGE_API_KEY` or `GOOGLE_API_KEY` when either is set, except `create-api-key`. If neither is set, dkcli falls back to ADC.
 
 When using local ADC, the Developer Knowledge API also requires a quota project. dkcli resolves that from `GOOGLE_CLOUD_QUOTA_PROJECT` or `quota_project_id` in the ADC file. The standard way to set that up is `gcloud auth application-default set-quota-project <project-id>`.
 

--- a/cmd/answerquery.go
+++ b/cmd/answerquery.go
@@ -1,0 +1,84 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+var answerQueryCmd = &cobra.Command{
+	Use:   "answer-query <query>...",
+	Short: "Answer a query using grounded generation",
+	Long: `Answer a query using the Developer Knowledge grounded generation API.
+
+This endpoint is currently exposed as v1alpha.
+
+If an API key is configured, dkcli uses it. Otherwise it falls back to ADC.`,
+	Args: cobra.MinimumNArgs(1),
+	RunE: runAnswerQuery,
+}
+
+func init() {
+	rootCmd.AddCommand(answerQueryCmd)
+}
+
+type answerQueryRequest struct {
+	Query string `json:"query"`
+}
+
+type Answer struct {
+	AnswerText string `json:"answerText" yaml:"answerText"`
+}
+
+type answerQueryResponse struct {
+	Answer Answer `json:"answer" yaml:"answer"`
+}
+
+func (c *apiClient) answerQuery(query string) (*answerQueryResponse, error) {
+	reqBody, err := json.Marshal(answerQueryRequest{Query: query})
+	if err != nil {
+		return nil, err
+	}
+
+	body, err := c.doJSONPost(answerQueryURL, reqBody)
+	if err != nil {
+		return nil, err
+	}
+
+	var resp answerQueryResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+func runAnswerQuery(cmd *cobra.Command, args []string) error {
+	client, err := newAPIClient(cmd.Context(), authPreferAPIKey)
+	if err != nil {
+		return err
+	}
+
+	resp, err := client.answerQuery(strings.Join(args, " "))
+	if err != nil {
+		return err
+	}
+
+	w, closer, err := outWriter(outputFile)
+	if err != nil {
+		return err
+	}
+	defer closer()
+
+	switch outputFormat {
+	case "text":
+		_, err = fmt.Fprintln(w, resp.Answer.AnswerText)
+		return err
+	case "txtar":
+		_, err = fmt.Fprint(w, txtarEntry("answer.txt", resp.Answer.AnswerText))
+		return err
+	default:
+		return writeFormatted(w, outputFormat, resp)
+	}
+}

--- a/cmd/answerquery.go
+++ b/cmd/answerquery.go
@@ -29,7 +29,7 @@ type answerQueryRequest struct {
 }
 
 type Answer struct {
-	AnswerText string `json:"answerText" yaml:"answerText"`
+	AnswerText string `json:"answerText" yaml:"answer_text"`
 }
 
 type answerQueryResponse struct {

--- a/cmd/answerquery.go
+++ b/cmd/answerquery.go
@@ -42,7 +42,7 @@ func (c *apiClient) answerQuery(query string) (*answerQueryResponse, error) {
 		return nil, err
 	}
 
-	body, err := c.doJSONPost(answerQueryURL, reqBody)
+	body, err := c.doJSONPost(c.baseURL+":answerQuery", reqBody)
 	if err != nil {
 		return nil, err
 	}
@@ -59,6 +59,7 @@ func runAnswerQuery(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+	client.baseURL = answerQueryBaseURL
 
 	resp, err := client.answerQuery(strings.Join(args, " "))
 	if err != nil {

--- a/cmd/answerquery_test.go
+++ b/cmd/answerquery_test.go
@@ -10,8 +10,6 @@ import (
 )
 
 func TestAnswerQuery(t *testing.T) {
-	t.Parallel()
-
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/v1alpha:answerQuery" {
 			http.Error(w, "not found", http.StatusNotFound)

--- a/cmd/answerquery_test.go
+++ b/cmd/answerquery_test.go
@@ -33,12 +33,8 @@ func TestAnswerQuery(t *testing.T) {
 	}))
 	t.Cleanup(srv.Close)
 
-	origURL := answerQueryURL
-	answerQueryURL = srv.URL + "/v1alpha:answerQuery"
-	t.Cleanup(func() { answerQueryURL = origURL })
-
 	client := &apiClient{
-		baseURL: srv.URL + "/v1",
+		baseURL: srv.URL + "/v1alpha",
 		client:  srv.Client(),
 		limiter: rate.NewLimiter(rate.Inf, 1),
 	}

--- a/cmd/answerquery_test.go
+++ b/cmd/answerquery_test.go
@@ -1,0 +1,55 @@
+package cmd
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"golang.org/x/time/rate"
+)
+
+func TestAnswerQuery(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1alpha:answerQuery" {
+			http.Error(w, "not found", http.StatusNotFound)
+			return
+		}
+		if r.Method != http.MethodPost {
+			t.Fatalf("method = %s, want POST", r.Method)
+		}
+
+		var req answerQueryRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatal(err)
+		}
+		if req.Query != "what is dkcli?" {
+			t.Fatalf("query = %q, want %q", req.Query, "what is dkcli?")
+		}
+
+		json.NewEncoder(w).Encode(answerQueryResponse{
+			Answer: Answer{AnswerText: "dkcli is a CLI for Developer Knowledge."},
+		})
+	}))
+	t.Cleanup(srv.Close)
+
+	origURL := answerQueryURL
+	answerQueryURL = srv.URL + "/v1alpha:answerQuery"
+	t.Cleanup(func() { answerQueryURL = origURL })
+
+	client := &apiClient{
+		baseURL: srv.URL + "/v1",
+		client:  srv.Client(),
+		limiter: rate.NewLimiter(rate.Inf, 0),
+	}
+
+	resp, err := client.answerQuery("what is dkcli?")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.Answer.AnswerText != "dkcli is a CLI for Developer Knowledge." {
+		t.Fatalf("answer = %q", resp.Answer.AnswerText)
+	}
+}

--- a/cmd/answerquery_test.go
+++ b/cmd/answerquery_test.go
@@ -40,7 +40,7 @@ func TestAnswerQuery(t *testing.T) {
 	client := &apiClient{
 		baseURL: srv.URL + "/v1",
 		client:  srv.Client(),
-		limiter: rate.NewLimiter(rate.Inf, 0),
+		limiter: rate.NewLimiter(rate.Inf, 1),
 	}
 
 	resp, err := client.answerQuery("what is dkcli?")

--- a/cmd/batchget.go
+++ b/cmd/batchget.go
@@ -282,17 +282,16 @@ func runBatchGet(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("--frontmatter can only be used with text format")
 	}
 
-	apiKey, err := getAPIKey()
-	if err != nil {
-		return err
-	}
-
 	names := make([]string, len(args))
 	for i, arg := range args {
 		names[i] = normalizeDocName(arg)
 	}
 
-	client := newAPIClient(apiKey)
+	client, err := newAPIClient(cmd.Context(), authPreferAPIKey)
+	if err != nil {
+		return err
+	}
+	client.baseURL = contentBaseURL
 
 	var docs []Document
 	var docErrs []error

--- a/cmd/batchget_test.go
+++ b/cmd/batchget_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"golang.org/x/time/rate"
@@ -19,7 +20,7 @@ func newTestClient(t *testing.T, handler http.Handler) *apiClient {
 	srv := httptest.NewServer(handler)
 	t.Cleanup(srv.Close)
 	return &apiClient{
-		baseURL: srv.URL + "/v1alpha",
+		baseURL: srv.URL + "/v1",
 		apiKey:  "test-key",
 		client:  srv.Client(),
 		limiter: rate.NewLimiter(rate.Inf, 0),
@@ -157,6 +158,7 @@ func TestFetchBatchGet(t *testing.T) {
 		resp := batchGetResponse{Documents: docs}
 		json.NewEncoder(w).Encode(resp)
 	}))
+	client.baseURL = strings.TrimSuffix(client.baseURL, "/v1") + "/v1alpha"
 
 	got, err := client.fetchBatchGet([]string{"documents/example.com/a", "documents/example.com/b"})
 	if err != nil {
@@ -187,6 +189,7 @@ func TestFetchBatchGet_APIError(t *testing.T) {
 			},
 		})
 	}))
+	client.baseURL = strings.TrimSuffix(client.baseURL, "/v1") + "/v1alpha"
 
 	_, err := client.fetchBatchGet([]string{"bad-name"})
 	if err == nil {
@@ -227,6 +230,7 @@ func TestFetchBatchBisect(t *testing.T) {
 		}
 		json.NewEncoder(w).Encode(batchGetResponse{Documents: docs})
 	}))
+	client.baseURL = strings.TrimSuffix(client.baseURL, "/v1") + "/v1alpha"
 
 	docs, docErrs, fatal := client.fetchBatchBisect([]string{
 		"documents/a", "documents/bad", "documents/b",
@@ -251,6 +255,7 @@ func TestFetchBatchBisect_NonBisectable(t *testing.T) {
 	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "internal server error", http.StatusInternalServerError)
 	}))
+	client.baseURL = strings.TrimSuffix(client.baseURL, "/v1") + "/v1alpha"
 
 	docs, docErrs, fatal := client.fetchBatchBisect([]string{"documents/a"})
 	if fatal == nil {

--- a/cmd/batchget_test.go
+++ b/cmd/batchget_test.go
@@ -23,7 +23,7 @@ func newTestClient(t *testing.T, handler http.Handler) *apiClient {
 		baseURL: srv.URL + "/v1",
 		apiKey:  "test-key",
 		client:  srv.Client(),
-		limiter: rate.NewLimiter(rate.Inf, 0),
+		limiter: rate.NewLimiter(rate.Inf, 1),
 		verbose: false,
 	}
 }

--- a/cmd/createapikey.go
+++ b/cmd/createapikey.go
@@ -254,14 +254,3 @@ func extractAPITargets(keyResp map[string]any) []string {
 	}
 	return services
 }
-
-type quotaProjectTransport struct {
-	Base    http.RoundTripper
-	Project string
-}
-
-func (t *quotaProjectTransport) RoundTrip(req *http.Request) (*http.Response, error) {
-	req = req.Clone(req.Context())
-	req.Header.Set("x-goog-user-project", t.Project)
-	return t.Base.RoundTrip(req)
-}

--- a/cmd/createapikey.go
+++ b/cmd/createapikey.go
@@ -53,8 +53,8 @@ func init() {
 }
 
 type createKeyRequest struct {
-	DisplayName  string            `json:"displayName"`
-	Restrictions keyRestrictions   `json:"restrictions"`
+	DisplayName  string          `json:"displayName"`
+	Restrictions keyRestrictions `json:"restrictions"`
 }
 
 type keyRestrictions struct {
@@ -80,7 +80,6 @@ type lroError struct {
 type keyStringResult struct {
 	KeyString string `json:"keyString"`
 }
-
 
 func resolveProjectID() string {
 	if projectID != "" {

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -11,7 +11,7 @@ import (
 
 var (
 	frontmatter bool
-	sizeOnly bool
+	sizeOnly    bool
 )
 
 var getCmd = &cobra.Command{
@@ -37,14 +37,22 @@ func init() {
 type DocumentMeta struct {
 	Name        string `yaml:"name"`
 	URI         string `yaml:"uri"`
+	Title       string `yaml:"title,omitempty"`
 	Description string `yaml:"description,omitempty"`
+	DataSource  string `yaml:"data_source,omitempty"`
+	UpdateTime  string `yaml:"update_time,omitempty"`
+	View        string `yaml:"view,omitempty"`
 }
 
 func formatDocWithFrontmatter(doc *Document) (string, error) {
 	meta := DocumentMeta{
 		Name:        doc.Name,
 		URI:         doc.URI,
+		Title:       doc.Title,
 		Description: doc.Description,
+		DataSource:  doc.DataSource,
+		UpdateTime:  doc.UpdateTime,
+		View:        doc.View,
 	}
 	buf, err := yaml.Marshal(meta)
 	if err != nil {
@@ -71,17 +79,14 @@ func formatDocText(doc *Document) string {
 }
 
 func runGet(cmd *cobra.Command, args []string) error {
-	apiKey, err := getAPIKey()
+	client, err := newAPIClient(cmd.Context(), authPreferAPIKey)
 	if err != nil {
 		return err
 	}
-
-	client := newAPIClient(apiKey)
+	client.baseURL = contentBaseURL
 
 	name := normalizeDocName(args[0])
-	url := client.baseURL + "/" + name
-
-	body, err := client.doGet(url)
+	body, err := client.fetchDocument(name)
 	if err != nil {
 		return err
 	}
@@ -122,4 +127,9 @@ func runGet(cmd *cobra.Command, args []string) error {
 	default:
 		return writeFormatted(w, outputFormat, doc)
 	}
+}
+
+func (c *apiClient) fetchDocument(name string) ([]byte, error) {
+	url := c.baseURL + "/" + name
+	return c.doGet(url)
 }

--- a/cmd/get_test.go
+++ b/cmd/get_test.go
@@ -59,7 +59,11 @@ func TestFormatDocWithFrontmatter(t *testing.T) {
 		doc := &Document{
 			Name:        "documents/example.com/page",
 			URI:         "https://example.com/page",
+			Title:       "Example Page",
 			Description: "A test page",
+			DataSource:  "example.com",
+			UpdateTime:  "2026-04-17T00:00:00Z",
+			View:        "DOCUMENT_VIEW_CONTENT",
 			Content:     "Hello world",
 		}
 		got, err := formatDocWithFrontmatter(doc)
@@ -74,6 +78,12 @@ func TestFormatDocWithFrontmatter(t *testing.T) {
 		}
 		if !strings.Contains(got, "uri: https://example.com/page") {
 			t.Error("expected uri in frontmatter")
+		}
+		if !strings.Contains(got, "title: Example Page") {
+			t.Error("expected title in frontmatter")
+		}
+		if !strings.Contains(got, "data_source: example.com") {
+			t.Error("expected data source in frontmatter")
 		}
 		if !strings.HasSuffix(got, "Hello world\n") {
 			t.Errorf("expected content at end, got suffix %q", got[len(got)-20:])
@@ -118,6 +128,7 @@ func TestFetchGet(t *testing.T) {
 		}
 		json.NewEncoder(w).Encode(doc)
 	}))
+	client.baseURL = strings.TrimSuffix(client.baseURL, "/v1") + "/v1alpha"
 
 	url := client.baseURL + "/documents/example.com/page"
 	body, err := client.doGet(url)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -9,11 +10,14 @@ import (
 	"net/http"
 	"net/http/httputil"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
+	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/google"
 	"golang.org/x/time/rate"
 	"gopkg.in/yaml.v3"
 )
@@ -27,7 +31,35 @@ var (
 	verbose      bool
 )
 
-var baseURL = "https://developerknowledge.googleapis.com/v1alpha"
+var (
+	searchBaseURL = "https://developerknowledge.googleapis.com/v1"
+	// Workaround: the live v1 get/batchGet methods currently return INTERNAL,
+	// so content retrieval stays on v1alpha until the backend catches up.
+	contentBaseURL = "https://developerknowledge.googleapis.com/v1alpha"
+	// Workaround: answerQuery is still documented and served on v1alpha.
+	answerQueryURL = "https://developerknowledge.googleapis.com/v1alpha:answerQuery"
+)
+
+const cloudPlatformScope = "https://www.googleapis.com/auth/cloud-platform"
+
+type authMode int
+
+const authPreferAPIKey authMode = iota
+
+var defaultTokenSource = func(ctx context.Context, scopes ...string) (oauth2.TokenSource, error) {
+	return google.DefaultTokenSource(ctx, scopes...)
+}
+
+var adcCredentialsPath = func() string {
+	if path := os.Getenv("GOOGLE_APPLICATION_CREDENTIALS"); path != "" {
+		return path
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(home, ".config", "gcloud", "application_default_credentials.json")
+}
 
 var rootCmd = &cobra.Command{
 	Use:   "dkcli",
@@ -56,33 +88,64 @@ type apiClient struct {
 	verbose bool
 }
 
+func apiKeyFromEnv() string {
+	if key := os.Getenv("DEVELOPERKNOWLEDGE_API_KEY"); key != "" {
+		return key
+	}
+	if key := os.Getenv("GOOGLE_API_KEY"); key != "" {
+		return key
+	}
+	return ""
+}
+
 // newAPIClient creates an apiClient using the global defaults.
-func newAPIClient(apiKey string) *apiClient {
-	return &apiClient{
-		baseURL: baseURL,
-		apiKey:  apiKey,
+func newAPIClient(ctx context.Context, mode authMode) (*apiClient, error) {
+	client := &apiClient{
+		baseURL: searchBaseURL,
 		client:  http.DefaultClient,
 		limiter: apiLimiter,
 		verbose: verbose,
 	}
+
+	if mode == authPreferAPIKey {
+		if apiKey := apiKeyFromEnv(); apiKey != "" {
+			client.apiKey = apiKey
+			return client, nil
+		}
+	}
+
+	tokenSource, err := defaultTokenSource(ctx, cloudPlatformScope)
+	if err != nil {
+		if mode == authPreferAPIKey {
+			return nil, fmt.Errorf("set DEVELOPERKNOWLEDGE_API_KEY or GOOGLE_API_KEY, or configure ADC with 'gcloud auth application-default login': %w", err)
+		}
+		return nil, fmt.Errorf("get credentials: %w (run 'gcloud auth application-default login')", err)
+	}
+
+	client.client = oauth2.NewClient(ctx, tokenSource)
+	if quotaProject := resolveQuotaProjectID(); quotaProject != "" {
+		baseTransport := client.client.Transport
+		if baseTransport == nil {
+			baseTransport = http.DefaultTransport
+		}
+		client.client.Transport = &quotaProjectTransport{
+			Base:    baseTransport,
+			Project: quotaProject,
+		}
+	}
+	return client, nil
 }
 
 // Document represents a Developer Knowledge API document.
 type Document struct {
 	Name        string `json:"name" yaml:"name"`
 	URI         string `json:"uri" yaml:"uri"`
-	Content     string `json:"content" yaml:"content"`
-	Description string `json:"description" yaml:"description"`
-}
-
-func getAPIKey() (string, error) {
-	if key := os.Getenv("DEVELOPERKNOWLEDGE_API_KEY"); key != "" {
-		return key, nil
-	}
-	if key := os.Getenv("GOOGLE_API_KEY"); key != "" {
-		return key, nil
-	}
-	return "", fmt.Errorf("set DEVELOPERKNOWLEDGE_API_KEY or GOOGLE_API_KEY")
+	Content     string `json:"content,omitempty" yaml:"content,omitempty"`
+	Description string `json:"description,omitempty" yaml:"description,omitempty"`
+	DataSource  string `json:"dataSource,omitempty" yaml:"dataSource,omitempty"`
+	Title       string `json:"title,omitempty" yaml:"title,omitempty"`
+	UpdateTime  string `json:"updateTime,omitempty" yaml:"updateTime,omitempty"`
+	View        string `json:"view,omitempty" yaml:"view,omitempty"`
 }
 
 // apiError represents a non-OK HTTP response from the API.
@@ -155,7 +218,7 @@ func checkResponse(resp *http.Response) ([]byte, error) {
 	return body, nil
 }
 
-func (c *apiClient) doGet(url string) ([]byte, error) {
+func (c *apiClient) doRequest(method, url string, body []byte, contentType string) ([]byte, error) {
 	const maxRetries = 3
 	backoff := 1 * time.Second
 
@@ -164,11 +227,20 @@ func (c *apiClient) doGet(url string) ([]byte, error) {
 			return nil, err
 		}
 
-		req, err := http.NewRequest(http.MethodGet, url, nil)
+		var requestBody io.Reader
+		if body != nil {
+			requestBody = bytes.NewReader(body)
+		}
+		req, err := http.NewRequest(method, url, requestBody)
 		if err != nil {
 			return nil, err
 		}
-		req.Header.Set("x-goog-api-key", c.apiKey)
+		if c.apiKey != "" {
+			req.Header.Set("x-goog-api-key", c.apiKey)
+		}
+		if contentType != "" {
+			req.Header.Set("Content-Type", contentType)
+		}
 
 		resp, err := c.client.Do(req)
 		if err != nil {
@@ -200,6 +272,14 @@ func (c *apiClient) doGet(url string) ([]byte, error) {
 	return nil, fmt.Errorf("exceeded max retries")
 }
 
+func (c *apiClient) doGet(url string) ([]byte, error) {
+	return c.doRequest(http.MethodGet, url, nil, "")
+}
+
+func (c *apiClient) doJSONPost(url string, body []byte) ([]byte, error) {
+	return c.doRequest(http.MethodPost, url, body, "application/json")
+}
+
 func normalizeDocName(name string) string {
 	name = strings.TrimPrefix(name, "https://")
 	name = strings.TrimPrefix(name, "http://")
@@ -207,6 +287,28 @@ func normalizeDocName(name string) string {
 		name = "documents/" + name
 	}
 	return name
+}
+
+func resolveQuotaProjectID() string {
+	if p := os.Getenv("GOOGLE_CLOUD_QUOTA_PROJECT"); p != "" {
+		return p
+	}
+
+	path := adcCredentialsPath()
+	if path == "" {
+		return ""
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return ""
+	}
+	var cfg struct {
+		QuotaProjectID string `json:"quota_project_id"`
+	}
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		return ""
+	}
+	return cfg.QuotaProjectID
 }
 
 // outWriter returns the writer for command output.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -235,7 +235,7 @@ func (c *apiClient) doAPIRequest(method, url string, body []byte, contentType st
 	const maxRetries = 3
 	backoff := 1 * time.Second
 	ctx := c.requestContext()
-	var lastErr error
+	var retryErr error
 
 	for attempt := 0; attempt < maxRetries; attempt++ {
 		if err := c.limiter.Wait(ctx); err != nil {
@@ -269,8 +269,11 @@ func (c *apiClient) doAPIRequest(method, url string, body []byte, contentType st
 
 		respBody, err := checkResponse(resp)
 		var rlErr *rateLimitError
-		if errors.As(err, &rlErr) && attempt < maxRetries-1 {
-			lastErr = err
+		if errors.As(err, &rlErr) {
+			retryErr = err
+			if attempt == maxRetries-1 {
+				break
+			}
 			wait := backoff
 			if rlErr.RetryAfter > 0 {
 				wait = rlErr.RetryAfter
@@ -286,7 +289,7 @@ func (c *apiClient) doAPIRequest(method, url string, body []byte, contentType st
 		}
 		return respBody, err
 	}
-	return nil, lastErr
+	return nil, retryErr
 }
 
 func (c *apiClient) requestContext() context.Context {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -50,6 +50,11 @@ var defaultTokenSource = func(ctx context.Context, scopes ...string) (oauth2.Tok
 	return google.DefaultTokenSource(ctx, scopes...)
 }
 
+type adcCredentialsMetadata struct {
+	Type           string `json:"type"`
+	QuotaProjectID string `json:"quota_project_id"`
+}
+
 var adcCredentialsPath = func() string {
 	if path := os.Getenv("GOOGLE_APPLICATION_CREDENTIALS"); path != "" {
 		return path
@@ -123,7 +128,11 @@ func newAPIClient(ctx context.Context, mode authMode) (*apiClient, error) {
 	}
 
 	client.client = oauth2.NewClient(ctx, tokenSource)
-	if quotaProject := resolveQuotaProjectID(); quotaProject != "" {
+	quotaProject, metadata := resolveQuotaProjectID()
+	if quotaProject == "" && metadata.Type == "authorized_user" {
+		return nil, fmt.Errorf("ADC requires a quota project; run 'gcloud auth application-default set-quota-project <project-id>' or set GOOGLE_CLOUD_QUOTA_PROJECT")
+	}
+	if quotaProject != "" {
 		baseTransport := client.client.Transport
 		if baseTransport == nil {
 			baseTransport = http.DefaultTransport
@@ -289,26 +298,40 @@ func normalizeDocName(name string) string {
 	return name
 }
 
-func resolveQuotaProjectID() string {
-	if p := os.Getenv("GOOGLE_CLOUD_QUOTA_PROJECT"); p != "" {
-		return p
-	}
-
+func loadADCCredentialsMetadata() adcCredentialsMetadata {
 	path := adcCredentialsPath()
 	if path == "" {
-		return ""
+		return adcCredentialsMetadata{}
 	}
 	data, err := os.ReadFile(path)
 	if err != nil {
-		return ""
+		return adcCredentialsMetadata{}
 	}
-	var cfg struct {
-		QuotaProjectID string `json:"quota_project_id"`
-	}
+	var cfg adcCredentialsMetadata
 	if err := json.Unmarshal(data, &cfg); err != nil {
-		return ""
+		return adcCredentialsMetadata{}
 	}
-	return cfg.QuotaProjectID
+	return cfg
+}
+
+func resolveQuotaProjectID() (string, adcCredentialsMetadata) {
+	if p := os.Getenv("GOOGLE_CLOUD_QUOTA_PROJECT"); p != "" {
+		return p, adcCredentialsMetadata{}
+	}
+
+	cfg := loadADCCredentialsMetadata()
+	return cfg.QuotaProjectID, cfg
+}
+
+type quotaProjectTransport struct {
+	Base    http.RoundTripper
+	Project string
+}
+
+func (t *quotaProjectTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	req = req.Clone(req.Context())
+	req.Header.Set("x-goog-user-project", t.Project)
+	return t.Base.RoundTrip(req)
 }
 
 // outWriter returns the writer for command output.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -235,6 +235,7 @@ func (c *apiClient) doAPIRequest(method, url string, body []byte, contentType st
 	const maxRetries = 3
 	backoff := 1 * time.Second
 	ctx := c.requestContext()
+	var lastErr error
 
 	for attempt := 0; attempt < maxRetries; attempt++ {
 		if err := c.limiter.Wait(ctx); err != nil {
@@ -269,6 +270,7 @@ func (c *apiClient) doAPIRequest(method, url string, body []byte, contentType st
 		body, err := checkResponse(resp)
 		var rlErr *rateLimitError
 		if errors.As(err, &rlErr) && attempt < maxRetries-1 {
+			lastErr = err
 			wait := backoff
 			if rlErr.RetryAfter > 0 {
 				wait = rlErr.RetryAfter
@@ -284,8 +286,7 @@ func (c *apiClient) doAPIRequest(method, url string, body []byte, contentType st
 		}
 		return body, err
 	}
-	// unreachable
-	return nil, fmt.Errorf("exceeded max retries")
+	return nil, lastErr
 }
 
 func (c *apiClient) requestContext() context.Context {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -37,7 +37,7 @@ var (
 	// so content retrieval stays on v1alpha until the backend catches up.
 	contentBaseURL = "https://developerknowledge.googleapis.com/v1alpha"
 	// Workaround: answerQuery is still documented and served on v1alpha.
-	answerQueryURL = "https://developerknowledge.googleapis.com/v1alpha:answerQuery"
+	answerQueryBaseURL = "https://developerknowledge.googleapis.com/v1alpha"
 )
 
 const cloudPlatformScope = "https://www.googleapis.com/auth/cloud-platform"

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -89,6 +89,7 @@ type apiClient struct {
 	baseURL string
 	apiKey  string
 	client  *http.Client
+	ctx     context.Context
 	limiter *rate.Limiter
 	verbose bool
 }
@@ -108,6 +109,7 @@ func newAPIClient(ctx context.Context, mode authMode) (*apiClient, error) {
 	client := &apiClient{
 		baseURL: searchBaseURL,
 		client:  http.DefaultClient,
+		ctx:     ctx,
 		limiter: apiLimiter,
 		verbose: verbose,
 	}
@@ -230,9 +232,10 @@ func checkResponse(resp *http.Response) ([]byte, error) {
 func (c *apiClient) doRequest(method, url string, body []byte, contentType string) ([]byte, error) {
 	const maxRetries = 3
 	backoff := 1 * time.Second
+	ctx := c.requestContext()
 
 	for attempt := range maxRetries {
-		if err := c.limiter.Wait(context.Background()); err != nil {
+		if err := c.limiter.Wait(ctx); err != nil {
 			return nil, err
 		}
 
@@ -240,7 +243,7 @@ func (c *apiClient) doRequest(method, url string, body []byte, contentType strin
 		if body != nil {
 			requestBody = bytes.NewReader(body)
 		}
-		req, err := http.NewRequest(method, url, requestBody)
+		req, err := http.NewRequestWithContext(ctx, method, url, requestBody)
 		if err != nil {
 			return nil, err
 		}
@@ -271,7 +274,9 @@ func (c *apiClient) doRequest(method, url string, body []byte, contentType strin
 			if c.verbose {
 				fmt.Fprintf(os.Stderr, "Rate limited, retrying after %v...\n", wait)
 			}
-			time.Sleep(wait)
+			if err := sleepContext(ctx, wait); err != nil {
+				return nil, err
+			}
 			backoff *= 2
 			continue
 		}
@@ -279,6 +284,24 @@ func (c *apiClient) doRequest(method, url string, body []byte, contentType strin
 	}
 	// unreachable
 	return nil, fmt.Errorf("exceeded max retries")
+}
+
+func (c *apiClient) requestContext() context.Context {
+	if c.ctx != nil {
+		return c.ctx
+	}
+	return context.Background()
+}
+
+func sleepContext(ctx context.Context, wait time.Duration) error {
+	timer := time.NewTimer(wait)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
 }
 
 func (c *apiClient) doGet(url string) ([]byte, error) {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -229,12 +229,12 @@ func checkResponse(resp *http.Response) ([]byte, error) {
 	return body, nil
 }
 
-func (c *apiClient) doRequest(method, url string, body []byte, contentType string) ([]byte, error) {
+func (c *apiClient) doAPIRequest(method, url string, body []byte, contentType string) ([]byte, error) {
 	const maxRetries = 3
 	backoff := 1 * time.Second
 	ctx := c.requestContext()
 
-	for attempt := range maxRetries {
+	for attempt := 0; attempt < maxRetries; attempt++ {
 		if err := c.limiter.Wait(ctx); err != nil {
 			return nil, err
 		}
@@ -305,11 +305,11 @@ func sleepContext(ctx context.Context, wait time.Duration) error {
 }
 
 func (c *apiClient) doGet(url string) ([]byte, error) {
-	return c.doRequest(http.MethodGet, url, nil, "")
+	return c.doAPIRequest(http.MethodGet, url, nil, "")
 }
 
 func (c *apiClient) doJSONPost(url string, body []byte) ([]byte, error) {
-	return c.doRequest(http.MethodPost, url, body, "application/json")
+	return c.doAPIRequest(http.MethodPost, url, body, "application/json")
 }
 
 func normalizeDocName(name string) string {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -59,11 +59,11 @@ var adcCredentialsPath = func() string {
 	if path := os.Getenv("GOOGLE_APPLICATION_CREDENTIALS"); path != "" {
 		return path
 	}
-	home, err := os.UserHomeDir()
+	configDir, err := os.UserConfigDir()
 	if err != nil {
 		return ""
 	}
-	return filepath.Join(home, ".config", "gcloud", "application_default_credentials.json")
+	return filepath.Join(configDir, "gcloud", "application_default_credentials.json")
 }
 
 var rootCmd = &cobra.Command{

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -41,6 +41,7 @@ var (
 )
 
 const cloudPlatformScope = "https://www.googleapis.com/auth/cloud-platform"
+const defaultHTTPTimeout = time.Minute
 
 type authMode int
 
@@ -108,7 +109,7 @@ func apiKeyFromEnv() string {
 func newAPIClient(ctx context.Context, mode authMode) (*apiClient, error) {
 	client := &apiClient{
 		baseURL: searchBaseURL,
-		client:  &http.Client{},
+		client:  &http.Client{Timeout: defaultHTTPTimeout},
 		ctx:     ctx,
 		limiter: apiLimiter,
 		verbose: verbose,
@@ -130,6 +131,7 @@ func newAPIClient(ctx context.Context, mode authMode) (*apiClient, error) {
 	}
 
 	client.client = oauth2.NewClient(ctx, tokenSource)
+	client.client.Timeout = defaultHTTPTimeout
 	quotaProject, metadata := resolveQuotaProjectID()
 	if quotaProject == "" && metadata.Type == "authorized_user" {
 		return nil, fmt.Errorf("ADC requires a quota project; run 'gcloud auth application-default set-quota-project <project-id>' or set GOOGLE_CLOUD_QUOTA_PROJECT")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -267,7 +267,7 @@ func (c *apiClient) doAPIRequest(method, url string, body []byte, contentType st
 			fmt.Fprintf(os.Stderr, "%s", dump)
 		}
 
-		body, err := checkResponse(resp)
+		respBody, err := checkResponse(resp)
 		var rlErr *rateLimitError
 		if errors.As(err, &rlErr) && attempt < maxRetries-1 {
 			lastErr = err
@@ -284,7 +284,7 @@ func (c *apiClient) doAPIRequest(method, url string, body []byte, contentType st
 			backoff *= 2
 			continue
 		}
-		return body, err
+		return respBody, err
 	}
 	return nil, lastErr
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -108,7 +108,7 @@ func apiKeyFromEnv() string {
 func newAPIClient(ctx context.Context, mode authMode) (*apiClient, error) {
 	client := &apiClient{
 		baseURL: searchBaseURL,
-		client:  http.DefaultClient,
+		client:  &http.Client{},
 		ctx:     ctx,
 		limiter: apiLimiter,
 		verbose: verbose,
@@ -153,9 +153,9 @@ type Document struct {
 	URI         string `json:"uri" yaml:"uri"`
 	Content     string `json:"content,omitempty" yaml:"content,omitempty"`
 	Description string `json:"description,omitempty" yaml:"description,omitempty"`
-	DataSource  string `json:"dataSource,omitempty" yaml:"dataSource,omitempty"`
+	DataSource  string `json:"dataSource,omitempty" yaml:"data_source,omitempty"`
 	Title       string `json:"title,omitempty" yaml:"title,omitempty"`
-	UpdateTime  string `json:"updateTime,omitempty" yaml:"updateTime,omitempty"`
+	UpdateTime  string `json:"updateTime,omitempty" yaml:"update_time,omitempty"`
 	View        string `json:"view,omitempty" yaml:"view,omitempty"`
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -11,6 +11,7 @@ import (
 	"net/http/httputil"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 	"time"
@@ -60,11 +61,24 @@ var adcCredentialsPath = func() string {
 	if path := os.Getenv("GOOGLE_APPLICATION_CREDENTIALS"); path != "" {
 		return path
 	}
-	configDir, err := os.UserConfigDir()
+	homeDir, err := os.UserHomeDir()
 	if err != nil {
+		homeDir = ""
+	}
+	return defaultADCCredentialsPath(runtime.GOOS, homeDir, os.Getenv("APPDATA"))
+}
+
+func defaultADCCredentialsPath(goos, homeDir, appData string) string {
+	if goos == "windows" {
+		if appData == "" {
+			return ""
+		}
+		return filepath.Join(appData, "gcloud", "application_default_credentials.json")
+	}
+	if homeDir == "" {
 		return ""
 	}
-	return filepath.Join(configDir, "gcloud", "application_default_credentials.json")
+	return filepath.Join(homeDir, ".config", "gcloud", "application_default_credentials.json")
 }
 
 var rootCmd = &cobra.Command{
@@ -259,6 +273,10 @@ func (c *apiClient) doAPIRequest(method, url string, body []byte, contentType st
 
 		resp, err := c.client.Do(req)
 		if err != nil {
+			if resp != nil && resp.Body != nil {
+				io.Copy(io.Discard, resp.Body)
+				resp.Body.Close()
+			}
 			return nil, err
 		}
 

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -3,15 +3,25 @@ package cmd
 import (
 	"context"
 	"encoding/json"
+	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"golang.org/x/oauth2"
+	"golang.org/x/time/rate"
 )
+
+type roundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripperFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
 
 func TestNewAPIClient_PrefersAPIKey(t *testing.T) {
 	t.Setenv("DEVELOPERKNOWLEDGE_API_KEY", "api-key")
@@ -154,5 +164,100 @@ func TestNewAPIClient_FailsFastWithoutQuotaProjectForUserADC(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "set-quota-project") {
 		t.Fatalf("error = %q, want quota project guidance", err)
+	}
+}
+
+func TestAPIClient_DoRequestHonorsCanceledContextWhileWaiting(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	called := false
+	client := &apiClient{
+		client: &http.Client{
+			Transport: roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+				called = true
+				return nil, nil
+			}),
+		},
+		ctx:     ctx,
+		limiter: rate.NewLimiter(rate.Every(time.Hour), 1),
+	}
+	client.limiter.Allow()
+
+	_, err := client.doGet("https://example.com")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("error = %v, want context.Canceled", err)
+	}
+	if called {
+		t.Fatal("request should not be attempted after context cancellation")
+	}
+}
+
+func TestAPIClient_DoRequestUsesRequestContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan error, 1)
+	client := &apiClient{
+		client: &http.Client{
+			Transport: roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+				<-req.Context().Done()
+				return nil, req.Context().Err()
+			}),
+		},
+		ctx:     ctx,
+		limiter: rate.NewLimiter(rate.Inf, 1),
+	}
+
+	go func() {
+		_, err := client.doGet("https://example.com")
+		done <- err
+	}()
+
+	cancel()
+
+	select {
+	case err := <-done:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("error = %v, want context.Canceled", err)
+		}
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("request did not observe context cancellation")
+	}
+}
+
+func TestAPIClient_DoRequestCancelsRetryBackoff(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	attempts := 0
+	client := &apiClient{
+		client: &http.Client{
+			Transport: roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+				attempts++
+				cancel()
+				return &http.Response{
+					StatusCode: http.StatusTooManyRequests,
+					Header:     http.Header{"Retry-After": []string{"60"}},
+					Body:       io.NopCloser(strings.NewReader("")),
+				}, nil
+			}),
+		},
+		ctx:     ctx,
+		limiter: rate.NewLimiter(rate.Inf, 1),
+	}
+
+	_, err := client.doGet("https://example.com")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("error = %v, want context.Canceled", err)
+	}
+	if attempts != 1 {
+		t.Fatalf("attempts = %d, want 1", attempts)
 	}
 }

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -15,6 +15,7 @@ import (
 
 	"golang.org/x/oauth2"
 	"golang.org/x/time/rate"
+	"gopkg.in/yaml.v3"
 )
 
 type roundTripperFunc func(*http.Request) (*http.Response, error)
@@ -40,8 +41,11 @@ func TestNewAPIClient_PrefersAPIKey(t *testing.T) {
 	if client.apiKey != "api-key" {
 		t.Fatalf("apiKey = %q, want %q", client.apiKey, "api-key")
 	}
-	if client.client != http.DefaultClient {
-		t.Fatal("expected default HTTP client when using API key auth")
+	if client.client == nil {
+		t.Fatal("expected HTTP client when using API key auth")
+	}
+	if client.client == http.DefaultClient {
+		t.Fatal("expected a dedicated HTTP client when using API key auth")
 	}
 }
 
@@ -259,5 +263,35 @@ func TestAPIClient_DoRequestCancelsRetryBackoff(t *testing.T) {
 	}
 	if attempts != 1 {
 		t.Fatalf("attempts = %d, want 1", attempts)
+	}
+}
+
+func TestYAMLTagsUseSnakeCase(t *testing.T) {
+	got, err := yaml.Marshal(map[string]any{
+		"document": Document{
+			DataSource: "example.com",
+			UpdateTime: "2026-04-18T00:00:00Z",
+		},
+		"search": searchResponse{
+			NextPageToken: "next-token",
+		},
+		"answer": answerQueryResponse{
+			Answer: Answer{AnswerText: "grounded"},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	text := string(got)
+	for _, want := range []string{"data_source:", "update_time:", "next_page_token:", "answer_text:"} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("yaml output %q does not contain %q", text, want)
+		}
+	}
+	for _, unwanted := range []string{"dataSource:", "updateTime:", "nextPageToken:", "answerText:"} {
+		if strings.Contains(text, unwanted) {
+			t.Fatalf("yaml output %q unexpectedly contains %q", text, unwanted)
+		}
 	}
 }

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"golang.org/x/oauth2"
@@ -93,7 +94,8 @@ func TestNewAPIClient_SetsQuotaProjectHeader(t *testing.T) {
 
 func TestResolveQuotaProjectID(t *testing.T) {
 	t.Setenv("GOOGLE_CLOUD_QUOTA_PROJECT", "quota-project")
-	if got := resolveQuotaProjectID(); got != "quota-project" {
+	got, _ := resolveQuotaProjectID()
+	if got != "quota-project" {
 		t.Fatalf("got %q, want %q", got, "quota-project")
 	}
 }
@@ -115,7 +117,42 @@ func TestResolveQuotaProjectIDFromADCFile(t *testing.T) {
 	adcCredentialsPath = func() string { return path }
 	t.Cleanup(func() { adcCredentialsPath = orig })
 
-	if got := resolveQuotaProjectID(); got != "from-file" {
+	got, _ := resolveQuotaProjectID()
+	if got != "from-file" {
 		t.Fatalf("got %q, want %q", got, "from-file")
+	}
+}
+
+func TestNewAPIClient_FailsFastWithoutQuotaProjectForUserADC(t *testing.T) {
+	t.Setenv("DEVELOPERKNOWLEDGE_API_KEY", "")
+	t.Setenv("GOOGLE_API_KEY", "")
+	t.Setenv("GOOGLE_CLOUD_QUOTA_PROJECT", "")
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "adc.json")
+	data, err := json.Marshal(map[string]string{"type": "authorized_user"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	origPath := adcCredentialsPath
+	adcCredentialsPath = func() string { return path }
+	t.Cleanup(func() { adcCredentialsPath = origPath })
+
+	origTokenSource := defaultTokenSource
+	defaultTokenSource = func(ctx context.Context, scopes ...string) (oauth2.TokenSource, error) {
+		return oauth2.StaticTokenSource(&oauth2.Token{AccessToken: "test-token"}), nil
+	}
+	t.Cleanup(func() { defaultTokenSource = origTokenSource })
+
+	_, err = newAPIClient(context.Background(), authPreferAPIKey)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "set-quota-project") {
+		t.Fatalf("error = %q, want quota project guidance", err)
 	}
 }

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1,0 +1,121 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"golang.org/x/oauth2"
+)
+
+func TestNewAPIClient_PrefersAPIKey(t *testing.T) {
+	t.Setenv("DEVELOPERKNOWLEDGE_API_KEY", "api-key")
+
+	orig := defaultTokenSource
+	defaultTokenSource = func(ctx context.Context, scopes ...string) (oauth2.TokenSource, error) {
+		t.Fatal("defaultTokenSource should not be called when API key is set")
+		return nil, nil
+	}
+	t.Cleanup(func() { defaultTokenSource = orig })
+
+	client, err := newAPIClient(context.Background(), authPreferAPIKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if client.apiKey != "api-key" {
+		t.Fatalf("apiKey = %q, want %q", client.apiKey, "api-key")
+	}
+	if client.client != http.DefaultClient {
+		t.Fatal("expected default HTTP client when using API key auth")
+	}
+}
+
+func TestNewAPIClient_FallsBackToADC(t *testing.T) {
+	t.Setenv("DEVELOPERKNOWLEDGE_API_KEY", "")
+	t.Setenv("GOOGLE_API_KEY", "")
+
+	orig := defaultTokenSource
+	defaultTokenSource = func(ctx context.Context, scopes ...string) (oauth2.TokenSource, error) {
+		if len(scopes) != 1 || scopes[0] != cloudPlatformScope {
+			t.Fatalf("scopes = %v, want [%q]", scopes, cloudPlatformScope)
+		}
+		return oauth2.StaticTokenSource(&oauth2.Token{AccessToken: "test-token"}), nil
+	}
+	t.Cleanup(func() { defaultTokenSource = orig })
+
+	client, err := newAPIClient(context.Background(), authPreferAPIKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if client.apiKey != "" {
+		t.Fatalf("apiKey = %q, want empty", client.apiKey)
+	}
+	if client.client == http.DefaultClient {
+		t.Fatal("expected OAuth HTTP client when falling back to ADC")
+	}
+}
+
+func TestNewAPIClient_SetsQuotaProjectHeader(t *testing.T) {
+	t.Setenv("DEVELOPERKNOWLEDGE_API_KEY", "")
+	t.Setenv("GOOGLE_API_KEY", "")
+	t.Setenv("GOOGLE_CLOUD_QUOTA_PROJECT", "quota-project")
+
+	orig := defaultTokenSource
+	defaultTokenSource = func(ctx context.Context, scopes ...string) (oauth2.TokenSource, error) {
+		return oauth2.StaticTokenSource(&oauth2.Token{AccessToken: "test-token"}), nil
+	}
+	t.Cleanup(func() { defaultTokenSource = orig })
+
+	var gotQuota string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotQuota = r.Header.Get("x-goog-user-project")
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+
+	client, err := newAPIClient(context.Background(), authPreferAPIKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp, err := client.client.Get(srv.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+	if gotQuota != "quota-project" {
+		t.Fatalf("x-goog-user-project = %q, want %q", gotQuota, "quota-project")
+	}
+}
+
+func TestResolveQuotaProjectID(t *testing.T) {
+	t.Setenv("GOOGLE_CLOUD_QUOTA_PROJECT", "quota-project")
+	if got := resolveQuotaProjectID(); got != "quota-project" {
+		t.Fatalf("got %q, want %q", got, "quota-project")
+	}
+}
+
+func TestResolveQuotaProjectIDFromADCFile(t *testing.T) {
+	t.Setenv("GOOGLE_CLOUD_QUOTA_PROJECT", "")
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "adc.json")
+	data, err := json.Marshal(map[string]string{"quota_project_id": "from-file"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	orig := adcCredentialsPath
+	adcCredentialsPath = func() string { return path }
+	t.Cleanup(func() { adcCredentialsPath = orig })
+
+	if got := resolveQuotaProjectID(); got != "from-file" {
+		t.Fatalf("got %q, want %q", got, "from-file")
+	}
+}

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -143,6 +143,52 @@ func TestResolveQuotaProjectIDFromADCFile(t *testing.T) {
 	}
 }
 
+func TestDefaultADCCredentialsPath(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		goos    string
+		homeDir string
+		appData string
+		want    string
+	}{
+		{
+			name:    "darwin uses xdg-compatible gcloud path",
+			goos:    "darwin",
+			homeDir: "/Users/alice",
+			want:    filepath.Join("/Users/alice", ".config", "gcloud", "application_default_credentials.json"),
+		},
+		{
+			name:    "linux uses xdg-compatible gcloud path",
+			goos:    "linux",
+			homeDir: "/home/alice",
+			want:    filepath.Join("/home/alice", ".config", "gcloud", "application_default_credentials.json"),
+		},
+		{
+			name:    "windows uses APPDATA",
+			goos:    "windows",
+			appData: filepath.Join("C:", "Users", "alice", "AppData", "Roaming"),
+			want:    filepath.Join("C:", "Users", "alice", "AppData", "Roaming", "gcloud", "application_default_credentials.json"),
+		},
+		{
+			name: "windows without APPDATA returns empty",
+			goos: "windows",
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := defaultADCCredentialsPath(tt.goos, tt.homeDir, tt.appData)
+			if got != tt.want {
+				t.Fatalf("defaultADCCredentialsPath(%q, %q, %q) = %q, want %q", tt.goos, tt.homeDir, tt.appData, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestNewAPIClient_FailsFastWithoutQuotaProjectForUserADC(t *testing.T) {
 	t.Setenv("DEVELOPERKNOWLEDGE_API_KEY", "")
 	t.Setenv("GOOGLE_API_KEY", "")

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -47,6 +47,9 @@ func TestNewAPIClient_PrefersAPIKey(t *testing.T) {
 	if client.client == http.DefaultClient {
 		t.Fatal("expected a dedicated HTTP client when using API key auth")
 	}
+	if client.client.Timeout != defaultHTTPTimeout {
+		t.Fatalf("timeout = %v, want %v", client.client.Timeout, defaultHTTPTimeout)
+	}
 }
 
 func TestNewAPIClient_FallsBackToADC(t *testing.T) {
@@ -71,6 +74,9 @@ func TestNewAPIClient_FallsBackToADC(t *testing.T) {
 	}
 	if client.client == http.DefaultClient {
 		t.Fatal("expected OAuth HTTP client when falling back to ADC")
+	}
+	if client.client.Timeout != defaultHTTPTimeout {
+		t.Fatalf("timeout = %v, want %v", client.client.Timeout, defaultHTTPTimeout)
 	}
 }
 

--- a/cmd/search.go
+++ b/cmd/search.go
@@ -47,7 +47,7 @@ type DocumentChunk struct {
 
 type searchResponse struct {
 	Results       []DocumentChunk `json:"results" yaml:"results"`
-	NextPageToken string          `json:"nextPageToken,omitempty" yaml:"nextPageToken,omitempty"`
+	NextPageToken string          `json:"nextPageToken,omitempty" yaml:"next_page_token,omitempty"`
 }
 
 // runSearchJSONL streams search results as JSONL, writing each chunk

--- a/cmd/search.go
+++ b/cmd/search.go
@@ -14,10 +14,11 @@ import (
 )
 
 var (
-	pageSize   int
-	pageToken  string
-	autoPaging bool
-	maxPages   int
+	pageSize     int
+	pageToken    string
+	autoPaging   bool
+	maxPages     int
+	searchFilter string
 )
 
 var searchCmd = &cobra.Command{
@@ -32,14 +33,16 @@ func init() {
 	searchCmd.Flags().StringVar(&pageToken, "page-token", "", "pagination token from previous response")
 	searchCmd.Flags().BoolVarP(&autoPaging, "auto-paging", "a", false, "automatically fetch subsequent pages")
 	searchCmd.Flags().IntVar(&maxPages, "max-pages", 5, "max pages to fetch with --auto-paging (0 for unlimited)")
+	searchCmd.Flags().StringVar(&searchFilter, "filter", "", "AIP-160 filter on document metadata")
 	rootCmd.AddCommand(searchCmd)
 }
 
 // DocumentChunk represents a search result chunk.
 type DocumentChunk struct {
-	Parent  string `json:"parent" yaml:"parent"`
-	ID      string `json:"id" yaml:"id"`
-	Content string `json:"content" yaml:"content"`
+	Parent   string    `json:"parent" yaml:"parent"`
+	ID       string    `json:"id" yaml:"id"`
+	Content  string    `json:"content" yaml:"content"`
+	Document *Document `json:"document,omitempty" yaml:"document,omitempty"`
 }
 
 type searchResponse struct {
@@ -58,7 +61,7 @@ func runSearchJSONL(w io.Writer, client *apiClient, query string) error {
 	var lastNextPageToken string
 
 	for {
-		resp, err := client.fetchSearchPage(query, pageSize, token)
+		resp, err := client.fetchSearchPage(query, pageSize, token, searchFilter)
 		if err != nil {
 			return err
 		}
@@ -93,7 +96,7 @@ func runSearchJSONL(w io.Writer, client *apiClient, query string) error {
 	return nil
 }
 
-func (c *apiClient) fetchSearchPage(query string, size int, token string) (*searchResponse, error) {
+func (c *apiClient) fetchSearchPage(query string, size int, token, filter string) (*searchResponse, error) {
 	params := url.Values{}
 	params.Set("query", query)
 	if size > 0 {
@@ -101,6 +104,9 @@ func (c *apiClient) fetchSearchPage(query string, size int, token string) (*sear
 	}
 	if token != "" {
 		params.Set("pageToken", token)
+	}
+	if filter != "" {
+		params.Set("filter", filter)
 	}
 
 	body, err := c.doGet(c.baseURL + "/documents:searchDocumentChunks?" + params.Encode())
@@ -116,7 +122,7 @@ func (c *apiClient) fetchSearchPage(query string, size int, token string) (*sear
 }
 
 func runSearch(cmd *cobra.Command, args []string) error {
-	apiKey, err := getAPIKey()
+	client, err := newAPIClient(cmd.Context(), authPreferAPIKey)
 	if err != nil {
 		return err
 	}
@@ -126,7 +132,6 @@ func runSearch(cmd *cobra.Command, args []string) error {
 		pageSize = 20
 	}
 
-	client := newAPIClient(apiKey)
 	query := strings.Join(args, " ")
 
 	w, closer, err := outWriter(outputFile)
@@ -145,7 +150,7 @@ func runSearch(cmd *cobra.Command, args []string) error {
 	start := time.Now()
 
 	for {
-		resp, err := client.fetchSearchPage(query, pageSize, token)
+		resp, err := client.fetchSearchPage(query, pageSize, token, searchFilter)
 		if err != nil {
 			return err
 		}
@@ -180,6 +185,23 @@ func runSearch(cmd *cobra.Command, args []string) error {
 				sb.WriteString("\n---\n")
 			}
 			fmt.Fprintf(&sb, "## %s [%s]\n\n", chunk.Parent, chunk.ID)
+			if chunk.Document != nil {
+				if chunk.Document.Title != "" {
+					fmt.Fprintf(&sb, "Title: %s\n", chunk.Document.Title)
+				}
+				if chunk.Document.DataSource != "" {
+					fmt.Fprintf(&sb, "Data source: %s\n", chunk.Document.DataSource)
+				}
+				if chunk.Document.UpdateTime != "" {
+					fmt.Fprintf(&sb, "Updated: %s\n", chunk.Document.UpdateTime)
+				}
+				if chunk.Document.URI != "" {
+					fmt.Fprintf(&sb, "URI: %s\n", chunk.Document.URI)
+				}
+				if chunk.Document.Title != "" || chunk.Document.DataSource != "" || chunk.Document.UpdateTime != "" || chunk.Document.URI != "" {
+					sb.WriteByte('\n')
+				}
+			}
 			sb.WriteString(chunk.Content)
 			sb.WriteByte('\n')
 		}

--- a/cmd/search_test.go
+++ b/cmd/search_test.go
@@ -12,14 +12,14 @@ func TestFetchSearchPage(t *testing.T) {
 
 	want := &searchResponse{
 		Results: []DocumentChunk{
-			{Parent: "documents/example.com/page", ID: "c1", Content: "content A"},
+			{Parent: "documents/example.com/page", ID: "c1", Content: "content A", Document: &Document{Title: "Page A", DataSource: "docs.cloud.google.com"}},
 			{Parent: "documents/example.com/other", ID: "c2", Content: "content B"},
 		},
 		NextPageToken: "next-token",
 	}
 
 	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/v1alpha/documents:searchDocumentChunks" {
+		if r.URL.Path != "/v1/documents:searchDocumentChunks" {
 			http.Error(w, "not found", http.StatusNotFound)
 			return
 		}
@@ -32,7 +32,7 @@ func TestFetchSearchPage(t *testing.T) {
 		json.NewEncoder(w).Encode(want)
 	}))
 
-	got, err := client.fetchSearchPage("test query", 0, "")
+	got, err := client.fetchSearchPage("test query", 0, "", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -44,6 +44,9 @@ func TestFetchSearchPage(t *testing.T) {
 	}
 	if got.NextPageToken != "next-token" {
 		t.Errorf("nextPageToken = %q, want %q", got.NextPageToken, "next-token")
+	}
+	if got.Results[0].Document == nil || got.Results[0].Document.Title != "Page A" {
+		t.Fatalf("expected embedded document metadata, got %+v", got.Results[0].Document)
 	}
 }
 
@@ -57,7 +60,7 @@ func TestFetchSearchPage_WithPageToken(t *testing.T) {
 		json.NewEncoder(w).Encode(&searchResponse{})
 	}))
 
-	_, err := client.fetchSearchPage("test", 0, "abc123")
+	_, err := client.fetchSearchPage("test", 0, "abc123", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -73,7 +76,23 @@ func TestFetchSearchPage_WithPageSize(t *testing.T) {
 		json.NewEncoder(w).Encode(&searchResponse{})
 	}))
 
-	_, err := client.fetchSearchPage("test", 10, "")
+	_, err := client.fetchSearchPage("test", 10, "", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestFetchSearchPage_WithFilter(t *testing.T) {
+	t.Parallel()
+
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.URL.Query().Get("filter"); got != `dataSource="docs.cloud.google.com"` {
+			t.Errorf("filter = %q, want %q", got, `dataSource="docs.cloud.google.com"`)
+		}
+		json.NewEncoder(w).Encode(&searchResponse{})
+	}))
+
+	_, err := client.fetchSearchPage("test", 0, "", `dataSource="docs.cloud.google.com"`)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -94,7 +113,7 @@ func TestFetchSearchPage_APIError(t *testing.T) {
 		})
 	}))
 
-	_, err := client.fetchSearchPage("", 0, "")
+	_, err := client.fetchSearchPage("", 0, "", "")
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}


### PR DESCRIPTION
## Summary
- update dkcli authentication to prefer API keys and fall back to ADC with a quota project header
- add grounded `answer-query` support and align command/docs behavior with verified live endpoint behavior
- replace Copilot-specific repo instructions with vendor-neutral `AGENTS.md` and expand tests around auth and endpoint selection

## Testing
- go build ./...
- go test ./... -race
- go vet ./...
