### PR TITLE
Fix create-api-key polling cancellation

### DIFF
--- a/cmd/createapikey.go
+++ b/cmd/createapikey.go
@@ -89,6 +89,13 @@ type keyStringResult struct {
 	KeyString string `json:"keyString"`
 }
 
+func apiKeyOperationTimeoutError(opName string) error {
+	if opName == "" {
+		return fmt.Errorf("operation timed out")
+	}
+	return fmt.Errorf("operation timed out: %s", opName)
+}
+
 func resolveProjectID() string {
 	if projectID != "" {
 		return projectID
@@ -184,6 +191,9 @@ func runCreateAPIKey(cmd *cobra.Command, args []string) error {
 	createURL := fmt.Sprintf("%s/projects/%s/locations/global/keys", apiKeysBaseURL, project)
 	body, err := doAPIKeysRequest(opCtx, client, http.MethodPost, createURL, reqBody, "application/json")
 	if err != nil {
+		if errors.Is(err, context.DeadlineExceeded) {
+			return apiKeyOperationTimeoutError("")
+		}
 		return err
 	}
 
@@ -195,7 +205,7 @@ func runCreateAPIKey(cmd *cobra.Command, args []string) error {
 	for !op.Done {
 		if err := sleepContext(opCtx, createAPIKeyPollInterval); err != nil {
 			if errors.Is(err, context.DeadlineExceeded) {
-				return fmt.Errorf("operation timed out: %s", op.Name)
+				return apiKeyOperationTimeoutError(op.Name)
 			}
 			return err
 		}
@@ -207,7 +217,7 @@ func runCreateAPIKey(cmd *cobra.Command, args []string) error {
 		pollBody, err := doAPIKeysRequest(opCtx, client, http.MethodGet, pollURL, nil, "")
 		if err != nil {
 			if errors.Is(err, context.DeadlineExceeded) {
-				return fmt.Errorf("operation timed out: %s", op.Name)
+				return apiKeyOperationTimeoutError(op.Name)
 			}
 			return err
 		}
@@ -243,7 +253,7 @@ func runCreateAPIKey(cmd *cobra.Command, args []string) error {
 	ksBody, err := doAPIKeysRequest(opCtx, client, http.MethodGet, ksURL, nil, "")
 	if err != nil {
 		if errors.Is(err, context.DeadlineExceeded) {
-			return fmt.Errorf("operation timed out: %s", op.Name)
+			return apiKeyOperationTimeoutError(op.Name)
 		}
 		return err
 	}

--- a/cmd/createapikey.go
+++ b/cmd/createapikey.go
@@ -13,7 +13,6 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
-	"golang.org/x/oauth2"
 )
 
 var (
@@ -110,35 +109,14 @@ func resolveProjectID() string {
 }
 
 func newAPIKeysClient(ctx context.Context) (*http.Client, error) {
-	ts, err := defaultTokenSource(ctx, cloudPlatformScope)
-	if err != nil {
-		return nil, fmt.Errorf("get credentials: %w (run 'gcloud auth application-default login')", err)
-	}
-
 	// runCreateAPIKey already wraps the whole API Keys LRO in a dedicated
 	// operation context, so this client intentionally leaves Timeout unset to
 	// avoid a second competing timeout source and keep timeout errors
 	// consistent.
-	client := oauth2.NewClient(ctx, ts)
-
-	quotaProject, metadata := resolveQuotaProjectID()
 	// Charge quota/billing to the configured ADC quota project, matching the
 	// rest of the CLI, rather than implicitly using the target project passed
 	// to --project.
-	if quotaProject == "" && metadata.Type == "authorized_user" {
-		return nil, fmt.Errorf("ADC requires a quota project; run 'gcloud auth application-default set-quota-project <project-id>' or set GOOGLE_CLOUD_QUOTA_PROJECT")
-	}
-	if quotaProject != "" {
-		baseTransport := client.Transport
-		if baseTransport == nil {
-			baseTransport = http.DefaultTransport
-		}
-		client.Transport = &quotaProjectTransport{
-			Base:    baseTransport,
-			Project: quotaProject,
-		}
-	}
-	return client, nil
+	return newADCHTTPClient(ctx, authRequireADC, 0)
 }
 
 func doAPIKeysRequest(ctx context.Context, client *http.Client, method, url string, body []byte, contentType string) ([]byte, error) {
@@ -161,7 +139,6 @@ func doAPIKeysRequest(ctx context.Context, client *http.Client, method, url stri
 	resp, err := client.Do(req)
 	if err != nil {
 		if resp != nil && resp.Body != nil {
-			_, _ = io.Copy(io.Discard, resp.Body)
 			_ = resp.Body.Close()
 		}
 		return nil, err

--- a/cmd/createapikey.go
+++ b/cmd/createapikey.go
@@ -2,8 +2,10 @@ package cmd
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"os"
 	"strings"
@@ -11,13 +13,18 @@ import (
 
 	"github.com/spf13/cobra"
 	"golang.org/x/oauth2"
-	"golang.org/x/oauth2/google"
 )
 
 var (
 	projectID   string
 	displayName string
 	keyOnly     bool
+)
+
+var (
+	apiKeysBaseURL             = "https://apikeys.googleapis.com/v2"
+	createAPIKeyPollInterval   = 2 * time.Second
+	createAPIKeyRequestTimeout = defaultHTTPTimeout
 )
 
 var createAPIKeyCmd = &cobra.Command{
@@ -94,6 +101,47 @@ func resolveProjectID() string {
 	return ""
 }
 
+func newAPIKeysClient(ctx context.Context, project string) (*http.Client, error) {
+	ts, err := defaultTokenSource(ctx, cloudPlatformScope)
+	if err != nil {
+		return nil, fmt.Errorf("get credentials: %w (run 'gcloud auth application-default login')", err)
+	}
+
+	client := oauth2.NewClient(ctx, ts)
+	client.Timeout = defaultHTTPTimeout
+
+	baseTransport := client.Transport
+	if baseTransport == nil {
+		baseTransport = http.DefaultTransport
+	}
+	client.Transport = &quotaProjectTransport{
+		Base:    baseTransport,
+		Project: project,
+	}
+	return client, nil
+}
+
+func doAPIKeysRequest(ctx context.Context, client *http.Client, method, url string, body []byte, contentType string) ([]byte, error) {
+	var requestBody io.Reader
+	if body != nil {
+		requestBody = bytes.NewReader(body)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, url, requestBody)
+	if err != nil {
+		return nil, err
+	}
+	if contentType != "" {
+		req.Header.Set("Content-Type", contentType)
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	return checkResponse(resp)
+}
+
 func runCreateAPIKey(cmd *cobra.Command, args []string) error {
 	project := resolveProjectID()
 	if project == "" {
@@ -102,15 +150,9 @@ func runCreateAPIKey(cmd *cobra.Command, args []string) error {
 
 	ctx := cmd.Context()
 
-	ts, err := google.DefaultTokenSource(ctx, "https://www.googleapis.com/auth/cloud-platform")
+	client, err := newAPIKeysClient(ctx, project)
 	if err != nil {
-		return fmt.Errorf("get credentials: %w (run 'gcloud auth application-default login')", err)
-	}
-	client := &http.Client{
-		Transport: &quotaProjectTransport{
-			Base:    &oauth2.Transport{Source: ts},
-			Project: project,
-		},
+		return err
 	}
 
 	// Create the API key
@@ -126,12 +168,8 @@ func runCreateAPIKey(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	createURL := fmt.Sprintf("https://apikeys.googleapis.com/v2/projects/%s/locations/global/keys", project)
-	resp, err := client.Post(createURL, "application/json", bytes.NewReader(reqBody))
-	if err != nil {
-		return err
-	}
-	body, err := checkResponse(resp)
+	createURL := fmt.Sprintf("%s/projects/%s/locations/global/keys", apiKeysBaseURL, project)
+	body, err := doAPIKeysRequest(ctx, client, http.MethodPost, createURL, reqBody, "application/json")
 	if err != nil {
 		return err
 	}
@@ -142,21 +180,20 @@ func runCreateAPIKey(cmd *cobra.Command, args []string) error {
 	}
 
 	// Poll until done
-	deadline := time.Now().Add(60 * time.Second)
+	deadline := time.Now().Add(createAPIKeyRequestTimeout)
 	for !op.Done {
 		if time.Now().After(deadline) {
 			return fmt.Errorf("operation timed out: %s", op.Name)
 		}
-		time.Sleep(2 * time.Second)
+		if err := sleepContext(ctx, createAPIKeyPollInterval); err != nil {
+			return err
+		}
 
 		if verbose {
 			fmt.Fprintf(os.Stderr, "Polling operation %s...\n", op.Name)
 		}
-		pollResp, err := client.Get("https://apikeys.googleapis.com/v2/" + op.Name)
-		if err != nil {
-			return err
-		}
-		pollBody, err := checkResponse(pollResp)
+		pollURL := fmt.Sprintf("%s/%s", apiKeysBaseURL, op.Name)
+		pollBody, err := doAPIKeysRequest(ctx, client, http.MethodGet, pollURL, nil, "")
 		if err != nil {
 			return err
 		}
@@ -188,11 +225,8 @@ func runCreateAPIKey(cmd *cobra.Command, args []string) error {
 	}
 
 	// Get key string (separate endpoint; not included in create response).
-	ksResp, err := client.Get(fmt.Sprintf("https://apikeys.googleapis.com/v2/%s/keyString", keyName))
-	if err != nil {
-		return err
-	}
-	ksBody, err := checkResponse(ksResp)
+	ksURL := fmt.Sprintf("%s/%s/keyString", apiKeysBaseURL, keyName)
+	ksBody, err := doAPIKeysRequest(ctx, client, http.MethodGet, ksURL, nil, "")
 	if err != nil {
 		return err
 	}

--- a/cmd/createapikey.go
+++ b/cmd/createapikey.go
@@ -115,9 +115,16 @@ func newAPIKeysClient(ctx context.Context) (*http.Client, error) {
 		return nil, fmt.Errorf("get credentials: %w (run 'gcloud auth application-default login')", err)
 	}
 
+	// runCreateAPIKey already wraps the whole API Keys LRO in a dedicated
+	// operation context, so this client intentionally leaves Timeout unset to
+	// avoid a second competing timeout source and keep timeout errors
+	// consistent.
 	client := oauth2.NewClient(ctx, ts)
 
 	quotaProject, metadata := resolveQuotaProjectID()
+	// Charge quota/billing to the configured ADC quota project, matching the
+	// rest of the CLI, rather than implicitly using the target project passed
+	// to --project.
 	if quotaProject == "" && metadata.Type == "authorized_user" {
 		return nil, fmt.Errorf("ADC requires a quota project; run 'gcloud auth application-default set-quota-project <project-id>' or set GOOGLE_CLOUD_QUOTA_PROJECT")
 	}
@@ -135,6 +142,9 @@ func newAPIKeysClient(ctx context.Context) (*http.Client, error) {
 }
 
 func doAPIKeysRequest(ctx context.Context, client *http.Client, method, url string, body []byte, contentType string) ([]byte, error) {
+	// create-api-key talks to the API Keys API via a short, bounded sequence of
+	// OAuth-authenticated requests, so it uses a dedicated helper instead of
+	// the Developer Knowledge-specific apiClient rate-limit/retry path.
 	var requestBody io.Reader
 	if body != nil {
 		requestBody = bytes.NewReader(body)
@@ -150,6 +160,10 @@ func doAPIKeysRequest(ctx context.Context, client *http.Client, method, url stri
 
 	resp, err := client.Do(req)
 	if err != nil {
+		if resp != nil && resp.Body != nil {
+			_, _ = io.Copy(io.Discard, resp.Body)
+			_ = resp.Body.Close()
+		}
 		return nil, err
 	}
 	return checkResponse(resp)

--- a/cmd/createapikey.go
+++ b/cmd/createapikey.go
@@ -138,12 +138,6 @@ func doAPIKeysRequest(ctx context.Context, client *http.Client, method, url stri
 
 	resp, err := client.Do(req)
 	if err != nil {
-		if resp != nil && resp.Body != nil {
-			// Mirror apiClient.doAPIRequest: some net/http error paths still hand
-			// back a response body that should be drained and closed before exit.
-			_, _ = io.Copy(io.Discard, resp.Body)
-			_ = resp.Body.Close()
-		}
 		return nil, err
 	}
 	return checkResponse(resp)

--- a/cmd/createapikey.go
+++ b/cmd/createapikey.go
@@ -116,7 +116,6 @@ func newAPIKeysClient(ctx context.Context) (*http.Client, error) {
 	}
 
 	client := oauth2.NewClient(ctx, ts)
-	client.Timeout = defaultHTTPTimeout
 
 	quotaProject, metadata := resolveQuotaProjectID()
 	if quotaProject == "" && metadata.Type == "authorized_user" {
@@ -151,10 +150,6 @@ func doAPIKeysRequest(ctx context.Context, client *http.Client, method, url stri
 
 	resp, err := client.Do(req)
 	if err != nil {
-		if resp != nil && resp.Body != nil {
-			_, _ = io.Copy(io.Discard, resp.Body)
-			_ = resp.Body.Close()
-		}
 		return nil, err
 	}
 	return checkResponse(resp)

--- a/cmd/createapikey.go
+++ b/cmd/createapikey.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -101,7 +102,7 @@ func resolveProjectID() string {
 	return ""
 }
 
-func newAPIKeysClient(ctx context.Context, project string) (*http.Client, error) {
+func newAPIKeysClient(ctx context.Context) (*http.Client, error) {
 	ts, err := defaultTokenSource(ctx, cloudPlatformScope)
 	if err != nil {
 		return nil, fmt.Errorf("get credentials: %w (run 'gcloud auth application-default login')", err)
@@ -110,13 +111,19 @@ func newAPIKeysClient(ctx context.Context, project string) (*http.Client, error)
 	client := oauth2.NewClient(ctx, ts)
 	client.Timeout = defaultHTTPTimeout
 
-	baseTransport := client.Transport
-	if baseTransport == nil {
-		baseTransport = http.DefaultTransport
+	quotaProject, metadata := resolveQuotaProjectID()
+	if quotaProject == "" && metadata.Type == "authorized_user" {
+		return nil, fmt.Errorf("ADC requires a quota project; run 'gcloud auth application-default set-quota-project <project-id>' or set GOOGLE_CLOUD_QUOTA_PROJECT")
 	}
-	client.Transport = &quotaProjectTransport{
-		Base:    baseTransport,
-		Project: project,
+	if quotaProject != "" {
+		baseTransport := client.Transport
+		if baseTransport == nil {
+			baseTransport = http.DefaultTransport
+		}
+		client.Transport = &quotaProjectTransport{
+			Base:    baseTransport,
+			Project: quotaProject,
+		}
 	}
 	return client, nil
 }
@@ -153,8 +160,10 @@ func runCreateAPIKey(cmd *cobra.Command, args []string) error {
 	}
 
 	ctx := cmd.Context()
+	opCtx, cancel := context.WithTimeout(ctx, createAPIKeyOperationTimeout)
+	defer cancel()
 
-	client, err := newAPIKeysClient(ctx, project)
+	client, err := newAPIKeysClient(opCtx)
 	if err != nil {
 		return err
 	}
@@ -173,7 +182,7 @@ func runCreateAPIKey(cmd *cobra.Command, args []string) error {
 	}
 
 	createURL := fmt.Sprintf("%s/projects/%s/locations/global/keys", apiKeysBaseURL, project)
-	body, err := doAPIKeysRequest(ctx, client, http.MethodPost, createURL, reqBody, "application/json")
+	body, err := doAPIKeysRequest(opCtx, client, http.MethodPost, createURL, reqBody, "application/json")
 	if err != nil {
 		return err
 	}
@@ -183,13 +192,11 @@ func runCreateAPIKey(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	// Poll until done
-	deadline := time.Now().Add(createAPIKeyOperationTimeout)
 	for !op.Done {
-		if time.Now().After(deadline) {
-			return fmt.Errorf("operation timed out: %s", op.Name)
-		}
-		if err := sleepContext(ctx, createAPIKeyPollInterval); err != nil {
+		if err := sleepContext(opCtx, createAPIKeyPollInterval); err != nil {
+			if errors.Is(err, context.DeadlineExceeded) {
+				return fmt.Errorf("operation timed out: %s", op.Name)
+			}
 			return err
 		}
 
@@ -197,8 +204,11 @@ func runCreateAPIKey(cmd *cobra.Command, args []string) error {
 			fmt.Fprintf(os.Stderr, "Polling operation %s...\n", op.Name)
 		}
 		pollURL := fmt.Sprintf("%s/%s", apiKeysBaseURL, op.Name)
-		pollBody, err := doAPIKeysRequest(ctx, client, http.MethodGet, pollURL, nil, "")
+		pollBody, err := doAPIKeysRequest(opCtx, client, http.MethodGet, pollURL, nil, "")
 		if err != nil {
+			if errors.Is(err, context.DeadlineExceeded) {
+				return fmt.Errorf("operation timed out: %s", op.Name)
+			}
 			return err
 		}
 		if err := json.Unmarshal(pollBody, &op); err != nil {
@@ -230,8 +240,11 @@ func runCreateAPIKey(cmd *cobra.Command, args []string) error {
 
 	// Get key string (separate endpoint; not included in create response).
 	ksURL := fmt.Sprintf("%s/%s/keyString", apiKeysBaseURL, keyName)
-	ksBody, err := doAPIKeysRequest(ctx, client, http.MethodGet, ksURL, nil, "")
+	ksBody, err := doAPIKeysRequest(opCtx, client, http.MethodGet, ksURL, nil, "")
 	if err != nil {
+		if errors.Is(err, context.DeadlineExceeded) {
+			return fmt.Errorf("operation timed out: %s", op.Name)
+		}
 		return err
 	}
 

--- a/cmd/createapikey.go
+++ b/cmd/createapikey.go
@@ -22,9 +22,9 @@ var (
 )
 
 var (
-	apiKeysBaseURL             = "https://apikeys.googleapis.com/v2"
-	createAPIKeyPollInterval   = 2 * time.Second
-	createAPIKeyRequestTimeout = defaultHTTPTimeout
+	apiKeysBaseURL               = "https://apikeys.googleapis.com/v2"
+	createAPIKeyPollInterval     = 2 * time.Second
+	createAPIKeyOperationTimeout = defaultHTTPTimeout
 )
 
 var createAPIKeyCmd = &cobra.Command{
@@ -137,6 +137,10 @@ func doAPIKeysRequest(ctx context.Context, client *http.Client, method, url stri
 
 	resp, err := client.Do(req)
 	if err != nil {
+		if resp != nil && resp.Body != nil {
+			_, _ = io.Copy(io.Discard, resp.Body)
+			_ = resp.Body.Close()
+		}
 		return nil, err
 	}
 	return checkResponse(resp)
@@ -180,7 +184,7 @@ func runCreateAPIKey(cmd *cobra.Command, args []string) error {
 	}
 
 	// Poll until done
-	deadline := time.Now().Add(createAPIKeyRequestTimeout)
+	deadline := time.Now().Add(createAPIKeyOperationTimeout)
 	for !op.Done {
 		if time.Now().After(deadline) {
 			return fmt.Errorf("operation timed out: %s", op.Name)

--- a/cmd/createapikey.go
+++ b/cmd/createapikey.go
@@ -139,6 +139,9 @@ func doAPIKeysRequest(ctx context.Context, client *http.Client, method, url stri
 	resp, err := client.Do(req)
 	if err != nil {
 		if resp != nil && resp.Body != nil {
+			// Mirror apiClient.doAPIRequest: some net/http error paths still hand
+			// back a response body that should be drained and closed before exit.
+			_, _ = io.Copy(io.Discard, resp.Body)
 			_ = resp.Body.Close()
 		}
 		return nil, err

--- a/cmd/createapikey_test.go
+++ b/cmd/createapikey_test.go
@@ -2,10 +2,14 @@ package cmd
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -139,12 +143,75 @@ func TestNewAPIKeysClient_UsesDefaultTimeout(t *testing.T) {
 	}
 	t.Cleanup(func() { defaultTokenSource = orig })
 
-	client, err := newAPIKeysClient(context.Background(), "test-project")
+	client, err := newAPIKeysClient(context.Background())
 	if err != nil {
 		t.Fatal(err)
 	}
 	if client.Timeout != defaultHTTPTimeout {
 		t.Fatalf("timeout = %v, want %v", client.Timeout, defaultHTTPTimeout)
+	}
+}
+
+func TestNewAPIKeysClient_UsesResolvedQuotaProject(t *testing.T) {
+	t.Setenv("GOOGLE_CLOUD_QUOTA_PROJECT", "quota-project")
+
+	orig := defaultTokenSource
+	defaultTokenSource = func(ctx context.Context, scopes ...string) (oauth2.TokenSource, error) {
+		return oauth2.StaticTokenSource(&oauth2.Token{AccessToken: "test-token"}), nil
+	}
+	t.Cleanup(func() { defaultTokenSource = orig })
+
+	client, err := newAPIKeysClient(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var gotQuota string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotQuota = r.Header.Get("x-goog-user-project")
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+
+	resp, err := client.Get(srv.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+	if gotQuota != "quota-project" {
+		t.Fatalf("x-goog-user-project = %q, want %q", gotQuota, "quota-project")
+	}
+}
+
+func TestNewAPIKeysClient_FailsWithoutQuotaProjectForUserADC(t *testing.T) {
+	t.Setenv("GOOGLE_CLOUD_QUOTA_PROJECT", "")
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "adc.json")
+	data, err := json.Marshal(map[string]string{"type": "authorized_user"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	origPath := adcCredentialsPath
+	adcCredentialsPath = func() string { return path }
+	t.Cleanup(func() { adcCredentialsPath = origPath })
+
+	origTokenSource := defaultTokenSource
+	defaultTokenSource = func(ctx context.Context, scopes ...string) (oauth2.TokenSource, error) {
+		return oauth2.StaticTokenSource(&oauth2.Token{AccessToken: "test-token"}), nil
+	}
+	t.Cleanup(func() { defaultTokenSource = origTokenSource })
+
+	_, err = newAPIKeysClient(context.Background())
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "set-quota-project") {
+		t.Fatalf("error = %q, want quota project guidance", err)
 	}
 }
 
@@ -257,5 +324,72 @@ func TestRunCreateAPIKey_HonorsCancellationWhilePolling(t *testing.T) {
 
 	if polls != 0 {
 		t.Fatalf("polls = %d, want 0", polls)
+	}
+}
+
+func TestRunCreateAPIKey_OperationTimeoutIsHardCapped(t *testing.T) {
+	origProjectID := projectID
+	origDisplayName := displayName
+	origKeyOnly := keyOnly
+	origOutputFormat := outputFormat
+	origOutputFile := outputFile
+	origVerbose := verbose
+	origBaseURL := apiKeysBaseURL
+	origPollInterval := createAPIKeyPollInterval
+	origTimeout := createAPIKeyOperationTimeout
+	t.Cleanup(func() {
+		projectID = origProjectID
+		displayName = origDisplayName
+		keyOnly = origKeyOnly
+		outputFormat = origOutputFormat
+		outputFile = origOutputFile
+		verbose = origVerbose
+		apiKeysBaseURL = origBaseURL
+		createAPIKeyPollInterval = origPollInterval
+		createAPIKeyOperationTimeout = origTimeout
+	})
+
+	projectID = "test-project"
+	displayName = "dkcli"
+	keyOnly = false
+	outputFormat = "text"
+	outputFile = ""
+	verbose = false
+	createAPIKeyPollInterval = 5 * time.Millisecond
+	createAPIKeyOperationTimeout = 20 * time.Millisecond
+
+	t.Setenv("GOOGLE_CLOUD_QUOTA_PROJECT", "quota-project")
+
+	origTokenSource := defaultTokenSource
+	defaultTokenSource = func(ctx context.Context, scopes ...string) (oauth2.TokenSource, error) {
+		return oauth2.StaticTokenSource(&oauth2.Token{AccessToken: "test-token"}), nil
+	}
+	t.Cleanup(func() { defaultTokenSource = origTokenSource })
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/v2/projects/test-project/locations/global/keys":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, `{"name":"operations/test-op","done":false}`)
+		case r.Method == http.MethodGet && r.URL.Path == "/v2/operations/test-op":
+			time.Sleep(100 * time.Millisecond)
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, `{"name":"operations/test-op","done":false}`)
+		default:
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	apiKeysBaseURL = srv.URL + "/v2"
+
+	cmd := &cobra.Command{}
+	cmd.SetContext(context.Background())
+
+	err := runCreateAPIKey(cmd, nil)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "operation timed out") {
+		t.Fatalf("error = %q, want timeout", err)
 	}
 }

--- a/cmd/createapikey_test.go
+++ b/cmd/createapikey_test.go
@@ -133,7 +133,7 @@ func TestQuotaProjectTransport(t *testing.T) {
 	}
 }
 
-func TestNewAPIKeysClient_UsesDefaultTimeout(t *testing.T) {
+func TestNewAPIKeysClient_LeavesClientTimeoutUnset(t *testing.T) {
 	t.Setenv("GOOGLE_CLOUD_QUOTA_PROJECT", "quota-project")
 
 	orig := defaultTokenSource
@@ -149,8 +149,8 @@ func TestNewAPIKeysClient_UsesDefaultTimeout(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if client.Timeout != defaultHTTPTimeout {
-		t.Fatalf("timeout = %v, want %v", client.Timeout, defaultHTTPTimeout)
+	if client.Timeout != 0 {
+		t.Fatalf("timeout = %v, want 0", client.Timeout)
 	}
 }
 

--- a/cmd/createapikey_test.go
+++ b/cmd/createapikey_test.go
@@ -181,7 +181,7 @@ func TestRunCreateAPIKey_HonorsCancellationWhilePolling(t *testing.T) {
 	origVerbose := verbose
 	origBaseURL := apiKeysBaseURL
 	origPollInterval := createAPIKeyPollInterval
-	origRequestTimeout := createAPIKeyRequestTimeout
+	origRequestTimeout := createAPIKeyOperationTimeout
 	t.Cleanup(func() {
 		projectID = origProjectID
 		displayName = origDisplayName
@@ -191,7 +191,7 @@ func TestRunCreateAPIKey_HonorsCancellationWhilePolling(t *testing.T) {
 		verbose = origVerbose
 		apiKeysBaseURL = origBaseURL
 		createAPIKeyPollInterval = origPollInterval
-		createAPIKeyRequestTimeout = origRequestTimeout
+		createAPIKeyOperationTimeout = origRequestTimeout
 	})
 
 	projectID = "test-project"
@@ -201,7 +201,7 @@ func TestRunCreateAPIKey_HonorsCancellationWhilePolling(t *testing.T) {
 	outputFile = ""
 	verbose = false
 	createAPIKeyPollInterval = time.Hour
-	createAPIKeyRequestTimeout = 2 * time.Hour
+	createAPIKeyOperationTimeout = 2 * time.Hour
 
 	origTokenSource := defaultTokenSource
 	defaultTokenSource = func(ctx context.Context, scopes ...string) (oauth2.TokenSource, error) {

--- a/cmd/createapikey_test.go
+++ b/cmd/createapikey_test.go
@@ -134,6 +134,8 @@ func TestQuotaProjectTransport(t *testing.T) {
 }
 
 func TestNewAPIKeysClient_UsesDefaultTimeout(t *testing.T) {
+	t.Setenv("GOOGLE_CLOUD_QUOTA_PROJECT", "quota-project")
+
 	orig := defaultTokenSource
 	defaultTokenSource = func(ctx context.Context, scopes ...string) (oauth2.TokenSource, error) {
 		if len(scopes) != 1 || scopes[0] != cloudPlatformScope {
@@ -269,6 +271,7 @@ func TestRunCreateAPIKey_HonorsCancellationWhilePolling(t *testing.T) {
 	verbose = false
 	createAPIKeyPollInterval = time.Hour
 	createAPIKeyOperationTimeout = 2 * time.Hour
+	t.Setenv("GOOGLE_CLOUD_QUOTA_PROJECT", "quota-project")
 
 	origTokenSource := defaultTokenSource
 	defaultTokenSource = func(ctx context.Context, scopes ...string) (oauth2.TokenSource, error) {
@@ -356,7 +359,7 @@ func TestRunCreateAPIKey_OperationTimeoutIsHardCapped(t *testing.T) {
 	outputFile = ""
 	verbose = false
 	createAPIKeyPollInterval = 5 * time.Millisecond
-	createAPIKeyOperationTimeout = 20 * time.Millisecond
+	createAPIKeyOperationTimeout = 200 * time.Millisecond
 
 	t.Setenv("GOOGLE_CLOUD_QUOTA_PROJECT", "quota-project")
 
@@ -391,5 +394,63 @@ func TestRunCreateAPIKey_OperationTimeoutIsHardCapped(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "operation timed out") {
 		t.Fatalf("error = %q, want timeout", err)
+	}
+}
+
+func TestRunCreateAPIKey_CreateRequestTimeoutUsesOperationTimeoutMessage(t *testing.T) {
+	origProjectID := projectID
+	origDisplayName := displayName
+	origKeyOnly := keyOnly
+	origOutputFormat := outputFormat
+	origOutputFile := outputFile
+	origVerbose := verbose
+	origBaseURL := apiKeysBaseURL
+	origPollInterval := createAPIKeyPollInterval
+	origTimeout := createAPIKeyOperationTimeout
+	t.Cleanup(func() {
+		projectID = origProjectID
+		displayName = origDisplayName
+		keyOnly = origKeyOnly
+		outputFormat = origOutputFormat
+		outputFile = origOutputFile
+		verbose = origVerbose
+		apiKeysBaseURL = origBaseURL
+		createAPIKeyPollInterval = origPollInterval
+		createAPIKeyOperationTimeout = origTimeout
+	})
+
+	projectID = "test-project"
+	displayName = "dkcli"
+	keyOnly = false
+	outputFormat = "text"
+	outputFile = ""
+	verbose = false
+	createAPIKeyOperationTimeout = 200 * time.Millisecond
+	t.Setenv("GOOGLE_CLOUD_QUOTA_PROJECT", "quota-project")
+
+	origTokenSource := defaultTokenSource
+	defaultTokenSource = func(ctx context.Context, scopes ...string) (oauth2.TokenSource, error) {
+		return oauth2.StaticTokenSource(&oauth2.Token{AccessToken: "test-token"}), nil
+	}
+	t.Cleanup(func() { defaultTokenSource = origTokenSource })
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/v2/projects/test-project/locations/global/keys" {
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+		time.Sleep(time.Second)
+	}))
+	t.Cleanup(srv.Close)
+	apiKeysBaseURL = srv.URL + "/v2"
+
+	cmd := &cobra.Command{}
+	cmd.SetContext(context.Background())
+
+	err := runCreateAPIKey(cmd, nil)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if err.Error() != "operation timed out" {
+		t.Fatalf("error = %q, want %q", err.Error(), "operation timed out")
 	}
 }

--- a/cmd/createapikey_test.go
+++ b/cmd/createapikey_test.go
@@ -1,9 +1,16 @@
 package cmd
 
 import (
+	"context"
+	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
+
+	"github.com/spf13/cobra"
+	"golang.org/x/oauth2"
 )
 
 func TestResolveProjectID(t *testing.T) {
@@ -119,5 +126,136 @@ func TestQuotaProjectTransport(t *testing.T) {
 
 	if gotHeader != "my-project" {
 		t.Errorf("x-goog-user-project = %q, want %q", gotHeader, "my-project")
+	}
+}
+
+func TestNewAPIKeysClient_UsesDefaultTimeout(t *testing.T) {
+	orig := defaultTokenSource
+	defaultTokenSource = func(ctx context.Context, scopes ...string) (oauth2.TokenSource, error) {
+		if len(scopes) != 1 || scopes[0] != cloudPlatformScope {
+			t.Fatalf("scopes = %v, want [%q]", scopes, cloudPlatformScope)
+		}
+		return oauth2.StaticTokenSource(&oauth2.Token{AccessToken: "test-token"}), nil
+	}
+	t.Cleanup(func() { defaultTokenSource = orig })
+
+	client, err := newAPIKeysClient(context.Background(), "test-project")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if client.Timeout != defaultHTTPTimeout {
+		t.Fatalf("timeout = %v, want %v", client.Timeout, defaultHTTPTimeout)
+	}
+}
+
+func TestDoAPIKeysRequest_UsesRequestContext(t *testing.T) {
+	type contextKey string
+
+	ctx := context.WithValue(context.Background(), contextKey("test"), "value")
+	called := false
+	client := &http.Client{
+		Transport: roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+			called = true
+			if got := req.Context().Value(contextKey("test")); got != "value" {
+				t.Fatalf("request context value = %v, want %q", got, "value")
+			}
+			return nil, context.Canceled
+		}),
+	}
+
+	_, err := doAPIKeysRequest(ctx, client, http.MethodGet, "https://example.com", nil, "")
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("error = %v, want context.Canceled", err)
+	}
+	if !called {
+		t.Fatal("expected request to reach transport")
+	}
+}
+
+func TestRunCreateAPIKey_HonorsCancellationWhilePolling(t *testing.T) {
+	origProjectID := projectID
+	origDisplayName := displayName
+	origKeyOnly := keyOnly
+	origOutputFormat := outputFormat
+	origOutputFile := outputFile
+	origVerbose := verbose
+	origBaseURL := apiKeysBaseURL
+	origPollInterval := createAPIKeyPollInterval
+	origRequestTimeout := createAPIKeyRequestTimeout
+	t.Cleanup(func() {
+		projectID = origProjectID
+		displayName = origDisplayName
+		keyOnly = origKeyOnly
+		outputFormat = origOutputFormat
+		outputFile = origOutputFile
+		verbose = origVerbose
+		apiKeysBaseURL = origBaseURL
+		createAPIKeyPollInterval = origPollInterval
+		createAPIKeyRequestTimeout = origRequestTimeout
+	})
+
+	projectID = "test-project"
+	displayName = "dkcli"
+	keyOnly = false
+	outputFormat = "text"
+	outputFile = ""
+	verbose = false
+	createAPIKeyPollInterval = time.Hour
+	createAPIKeyRequestTimeout = 2 * time.Hour
+
+	origTokenSource := defaultTokenSource
+	defaultTokenSource = func(ctx context.Context, scopes ...string) (oauth2.TokenSource, error) {
+		return oauth2.StaticTokenSource(&oauth2.Token{AccessToken: "test-token"}), nil
+	}
+	t.Cleanup(func() { defaultTokenSource = origTokenSource })
+
+	created := make(chan struct{}, 1)
+	polls := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/v2/projects/test-project/locations/global/keys":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, `{"name":"operations/test-op","done":false}`)
+			select {
+			case created <- struct{}{}:
+			default:
+			}
+		case r.Method == http.MethodGet && r.URL.Path == "/v2/operations/test-op":
+			polls++
+			t.Fatalf("unexpected poll request after cancellation")
+		default:
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	apiKeysBaseURL = srv.URL + "/v2"
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cmd := &cobra.Command{}
+	cmd.SetContext(ctx)
+
+	done := make(chan error, 1)
+	go func() {
+		done <- runCreateAPIKey(cmd, nil)
+	}()
+
+	select {
+	case <-created:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for create request")
+	}
+	cancel()
+
+	select {
+	case err := <-done:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("error = %v, want context.Canceled", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("runCreateAPIKey did not exit after cancellation")
+	}
+
+	if polls != 0 {
+		t.Fatalf("polls = %d, want 0", polls)
 	}
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -154,7 +154,6 @@ func newADCHTTPClient(ctx context.Context, mode authMode, timeout time.Duration)
 func newAPIClient(ctx context.Context, mode authMode) (*apiClient, error) {
 	client := &apiClient{
 		baseURL: searchBaseURL,
-		client:  &http.Client{Timeout: defaultHTTPTimeout},
 		ctx:     ctx,
 		limiter: apiLimiter,
 		verbose: verbose,
@@ -163,6 +162,7 @@ func newAPIClient(ctx context.Context, mode authMode) (*apiClient, error) {
 	if mode == authPreferAPIKey {
 		if apiKey := apiKeyFromEnv(); apiKey != "" {
 			client.apiKey = apiKey
+			client.client = &http.Client{Timeout: defaultHTTPTimeout}
 			return client, nil
 		}
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -43,7 +43,10 @@ const defaultHTTPTimeout = time.Minute
 
 type authMode int
 
-const authPreferAPIKey authMode = iota
+const (
+	authPreferAPIKey authMode = iota
+	authRequireADC
+)
 
 var defaultTokenSource = func(ctx context.Context, scopes ...string) (oauth2.TokenSource, error) {
 	return google.DefaultTokenSource(ctx, scopes...)
@@ -116,6 +119,37 @@ func apiKeyFromEnv() string {
 	return ""
 }
 
+func newADCHTTPClient(ctx context.Context, mode authMode, timeout time.Duration) (*http.Client, error) {
+	tokenSource, err := defaultTokenSource(ctx, cloudPlatformScope)
+	if err != nil {
+		if mode == authPreferAPIKey {
+			return nil, fmt.Errorf("set DEVELOPERKNOWLEDGE_API_KEY or GOOGLE_API_KEY, or configure ADC with 'gcloud auth application-default login': %w", err)
+		}
+		return nil, fmt.Errorf("get credentials: %w (run 'gcloud auth application-default login')", err)
+	}
+
+	client := oauth2.NewClient(ctx, tokenSource)
+	if timeout > 0 {
+		client.Timeout = timeout
+	}
+
+	quotaProject, metadata := resolveQuotaProjectID()
+	if quotaProject == "" && metadata.Type == "authorized_user" {
+		return nil, fmt.Errorf("ADC requires a quota project; run 'gcloud auth application-default set-quota-project <project-id>' or set GOOGLE_CLOUD_QUOTA_PROJECT")
+	}
+	if quotaProject != "" {
+		baseTransport := client.Transport
+		if baseTransport == nil {
+			baseTransport = http.DefaultTransport
+		}
+		client.Transport = &quotaProjectTransport{
+			Base:    baseTransport,
+			Project: quotaProject,
+		}
+	}
+	return client, nil
+}
+
 // newAPIClient creates an apiClient using the global defaults.
 func newAPIClient(ctx context.Context, mode authMode) (*apiClient, error) {
 	client := &apiClient{
@@ -133,29 +167,10 @@ func newAPIClient(ctx context.Context, mode authMode) (*apiClient, error) {
 		}
 	}
 
-	tokenSource, err := defaultTokenSource(ctx, cloudPlatformScope)
+	var err error
+	client.client, err = newADCHTTPClient(ctx, mode, defaultHTTPTimeout)
 	if err != nil {
-		if mode == authPreferAPIKey {
-			return nil, fmt.Errorf("set DEVELOPERKNOWLEDGE_API_KEY or GOOGLE_API_KEY, or configure ADC with 'gcloud auth application-default login': %w", err)
-		}
-		return nil, fmt.Errorf("get credentials: %w (run 'gcloud auth application-default login')", err)
-	}
-
-	client.client = oauth2.NewClient(ctx, tokenSource)
-	client.client.Timeout = defaultHTTPTimeout
-	quotaProject, metadata := resolveQuotaProjectID()
-	if quotaProject == "" && metadata.Type == "authorized_user" {
-		return nil, fmt.Errorf("ADC requires a quota project; run 'gcloud auth application-default set-quota-project <project-id>' or set GOOGLE_CLOUD_QUOTA_PROJECT")
-	}
-	if quotaProject != "" {
-		baseTransport := client.client.Transport
-		if baseTransport == nil {
-			baseTransport = http.DefaultTransport
-		}
-		client.client.Transport = &quotaProjectTransport{
-			Base:    baseTransport,
-			Project: quotaProject,
-		}
+		return nil, err
 	}
 	return client, nil
 }


### PR DESCRIPTION
## Summary
- make create-api-key API Keys requests use the command context and the shared default timeout
- replace polling sleep with a context-aware wait
- add regression coverage for the new client/request helpers and canceled polling

Closes #2