### PR TITLE
Protect create-api-key output files

### DIFF
--- a/cmd/createapikey.go
+++ b/cmd/createapikey.go
@@ -104,26 +104,35 @@ func createAPIKeyOutWriter(file string) (io.Writer, func(), error) {
 		return os.Stdout, func() {}, nil
 	}
 
-	info, err := os.Lstat(file)
+	f, err := openExistingCreateAPIKeyFile(file)
 	switch {
 	case err == nil:
-		if info.Mode()&os.ModeSymlink != 0 {
-			return nil, nil, fmt.Errorf("refusing to write secret to symlink %q", file)
+		info, err := f.Stat()
+		if err != nil {
+			_ = f.Close()
+			return nil, nil, err
 		}
 		if !info.Mode().IsRegular() {
+			_ = f.Close()
 			return nil, nil, fmt.Errorf("refusing to write secret to non-regular file %q", file)
 		}
 		if runtime.GOOS != "windows" {
 			perms := info.Mode().Perm()
 			if perms&0o077 != 0 {
+				_ = f.Close()
 				return nil, nil, fmt.Errorf("refusing to write secret to %q with permissions %04o; use owner-only permissions with owner write (for example 0600)", file, perms)
 			}
 			if perms&0o200 == 0 {
+				_ = f.Close()
 				return nil, nil, fmt.Errorf("refusing to write secret to %q without owner write permission; use owner-only permissions with owner write (for example 0600)", file)
 			}
 		}
-		f, err := os.OpenFile(file, os.O_WRONLY|os.O_TRUNC, 0)
-		if err != nil {
+		if err := f.Truncate(0); err != nil {
+			_ = f.Close()
+			return nil, nil, err
+		}
+		if _, err := f.Seek(0, io.SeekStart); err != nil {
+			_ = f.Close()
 			return nil, nil, err
 		}
 		return f, func() { f.Close() }, nil
@@ -134,6 +143,15 @@ func createAPIKeyOutWriter(file string) (io.Writer, func(), error) {
 		}
 		return f, func() { f.Close() }, nil
 	default:
+		if runtime.GOOS != "windows" && errors.Is(err, os.ErrPermission) {
+			info, statErr := os.Lstat(file)
+			if statErr == nil && info.Mode()&os.ModeSymlink == 0 && info.Mode().IsRegular() {
+				perms := info.Mode().Perm()
+				if perms&0o077 == 0 && perms&0o200 == 0 {
+					return nil, nil, fmt.Errorf("refusing to write secret to %q without owner write permission; use owner-only permissions with owner write (for example 0600)", file)
+				}
+			}
+		}
 		return nil, nil, err
 	}
 }

--- a/cmd/createapikey.go
+++ b/cmd/createapikey.go
@@ -149,7 +149,7 @@ func createAPIKeyOutWriter(file string) (io.Writer, func(), error) {
 	default:
 		if runtime.GOOS != "windows" && errors.Is(err, os.ErrPermission) {
 			info, statErr := os.Lstat(file)
-			if statErr == nil && info.Mode()&os.ModeSymlink == 0 && info.Mode().IsRegular() {
+			if statErr == nil && info.Mode().IsRegular() {
 				perms := info.Mode().Perm()
 				if perms&0o077 == 0 && perms&0o200 == 0 {
 					return nil, nil, fmt.Errorf("refusing to write secret to %q without owner write permission; use owner-only permissions with owner write (for example 0600)", file)

--- a/cmd/createapikey.go
+++ b/cmd/createapikey.go
@@ -295,13 +295,21 @@ func runCreateAPIKey(cmd *cobra.Command, args []string) error {
 		fmt.Fprintf(os.Stderr, "WARNING: format %q not supported for create-api-key, falling back to text\n", outputFormat)
 	}
 	if outputFormat == "text" || outputFormat == "txtar" {
-		fmt.Fprintf(w, "Name:          %s\n", keyName)
-		if dn, ok := keyResp["displayName"].(string); ok && dn != "" {
-			fmt.Fprintf(w, "Display Name:  %s\n", dn)
+		if _, err := fmt.Fprintf(w, "Name:          %s\n", keyName); err != nil {
+			return finishWrite(err)
 		}
-		fmt.Fprintf(w, "API Key:       %s\n", ks.KeyString)
+		if dn, ok := keyResp["displayName"].(string); ok && dn != "" {
+			if _, err := fmt.Fprintf(w, "Display Name:  %s\n", dn); err != nil {
+				return finishWrite(err)
+			}
+		}
+		if _, err := fmt.Fprintf(w, "API Key:       %s\n", ks.KeyString); err != nil {
+			return finishWrite(err)
+		}
 		if targets := extractAPITargets(keyResp); len(targets) > 0 {
-			fmt.Fprintf(w, "Restricted to: %s\n", strings.Join(targets, ", "))
+			if _, err := fmt.Fprintf(w, "Restricted to: %s\n", strings.Join(targets, ", ")); err != nil {
+				return finishWrite(err)
+			}
 		}
 		return finishWrite(nil)
 	}

--- a/cmd/createapikey.go
+++ b/cmd/createapikey.go
@@ -141,6 +141,10 @@ func createAPIKeyOutWriter(file string) (io.Writer, func(), error) {
 		if err != nil {
 			return nil, nil, err
 		}
+		if err := f.Chmod(createAPIKeyFileMode); err != nil {
+			_ = f.Close()
+			return nil, nil, err
+		}
 		return f, func() { f.Close() }, nil
 	default:
 		if runtime.GOOS != "windows" && errors.Is(err, os.ErrPermission) {

--- a/cmd/createapikey.go
+++ b/cmd/createapikey.go
@@ -3,7 +3,9 @@ package cmd
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"os"
 	"strings"
@@ -81,6 +83,8 @@ type keyStringResult struct {
 	KeyString string `json:"keyString"`
 }
 
+const createAPIKeyFileMode = 0o600
+
 func resolveProjectID() string {
 	if projectID != "" {
 		return projectID
@@ -92,6 +96,36 @@ func resolveProjectID() string {
 		return p
 	}
 	return ""
+}
+
+func createAPIKeyOutWriter(file string) (io.Writer, func(), error) {
+	if file == "" {
+		return os.Stdout, func() {}, nil
+	}
+
+	info, err := os.Stat(file)
+	switch {
+	case err == nil:
+		if !info.Mode().IsRegular() {
+			return nil, nil, fmt.Errorf("refusing to write secret to non-regular file %q", file)
+		}
+		if info.Mode().Perm()&0o077 != 0 {
+			return nil, nil, fmt.Errorf("refusing to write secret to %q with permissions %04o; use 0600 or stricter", file, info.Mode().Perm())
+		}
+		f, err := os.OpenFile(file, os.O_WRONLY|os.O_TRUNC, 0)
+		if err != nil {
+			return nil, nil, err
+		}
+		return f, func() { f.Close() }, nil
+	case errors.Is(err, os.ErrNotExist):
+		f, err := os.OpenFile(file, os.O_CREATE|os.O_EXCL|os.O_WRONLY, createAPIKeyFileMode)
+		if err != nil {
+			return nil, nil, err
+		}
+		return f, func() { f.Close() }, nil
+	default:
+		return nil, nil, err
+	}
 }
 
 func runCreateAPIKey(cmd *cobra.Command, args []string) error {
@@ -205,7 +239,7 @@ func runCreateAPIKey(cmd *cobra.Command, args []string) error {
 	// Add keyString to the full key resource for structured output.
 	keyResp["keyString"] = ks.KeyString
 
-	w, closer, err := outWriter(outputFile)
+	w, closer, err := createAPIKeyOutWriter(outputFile)
 	if err != nil {
 		return err
 	}

--- a/cmd/createapikey.go
+++ b/cmd/createapikey.go
@@ -95,6 +95,16 @@ func ownerOnlyPermissionExample() string {
 	return fmt.Sprintf("%04o", createAPIKeyFileMode)
 }
 
+func validateOwnerOnlyPermissions(file string, perms os.FileMode) error {
+	if perms&0o077 != 0 {
+		return fmt.Errorf("refusing to write secret to %q with permissions %04o; use owner-only permissions with owner write (for example %s)", file, perms, ownerOnlyPermissionExample())
+	}
+	if perms&0o200 == 0 {
+		return fmt.Errorf("refusing to write secret to %q without owner write permission; use owner-only permissions with owner write (for example %s)", file, ownerOnlyPermissionExample())
+	}
+	return nil
+}
+
 func warnWindowsOutputACL(file string) {
 	if runtime.GOOS == "windows" {
 		fmt.Fprintf(os.Stderr, "WARNING: Windows does not enforce owner-only access via mode bits for %q; secret file access depends on the directory ACLs\n", file)
@@ -139,14 +149,9 @@ func createAPIKeyOutWriter(file string) (io.Writer, func() error, error) {
 			return nil, nil, fmt.Errorf("refusing to write secret to non-regular file %q", file)
 		}
 		if runtime.GOOS != "windows" {
-			perms := info.Mode().Perm()
-			if perms&0o077 != 0 {
+			if err := validateOwnerOnlyPermissions(file, info.Mode().Perm()); err != nil {
 				_ = f.Close()
-				return nil, nil, fmt.Errorf("refusing to write secret to %q with permissions %04o; use owner-only permissions with owner write (for example %s)", file, perms, ownerOnlyPermissionExample())
-			}
-			if perms&0o200 == 0 {
-				_ = f.Close()
-				return nil, nil, fmt.Errorf("refusing to write secret to %q without owner write permission; use owner-only permissions with owner write (for example %s)", file, ownerOnlyPermissionExample())
+				return nil, nil, err
 			}
 		}
 		if err := f.Truncate(0); err != nil {
@@ -175,12 +180,8 @@ func createAPIKeyOutWriter(file string) (io.Writer, func() error, error) {
 		if runtime.GOOS != "windows" && errors.Is(err, os.ErrPermission) {
 			info, statErr := os.Lstat(file)
 			if statErr == nil && info.Mode().IsRegular() {
-				perms := info.Mode().Perm()
-				if perms&0o077 != 0 {
-					return nil, nil, fmt.Errorf("refusing to write secret to %q with permissions %04o; use owner-only permissions with owner write (for example %s)", file, perms, ownerOnlyPermissionExample())
-				}
-				if perms&0o200 == 0 {
-					return nil, nil, fmt.Errorf("refusing to write secret to %q without owner write permission; use owner-only permissions with owner write (for example %s)", file, ownerOnlyPermissionExample())
+				if err := validateOwnerOnlyPermissions(file, info.Mode().Perm()); err != nil {
+					return nil, nil, err
 				}
 			}
 		}

--- a/cmd/createapikey.go
+++ b/cmd/createapikey.go
@@ -86,6 +86,12 @@ type keyStringResult struct {
 
 const createAPIKeyFileMode = 0o600
 
+func warnWindowsOutputACL(file string) {
+	if runtime.GOOS == "windows" {
+		fmt.Fprintf(os.Stderr, "WARNING: Windows does not enforce owner-only access via mode bits for %q; secret file access depends on the directory ACLs\n", file)
+	}
+}
+
 func resolveProjectID() string {
 	if projectID != "" {
 		return projectID
@@ -135,6 +141,7 @@ func createAPIKeyOutWriter(file string) (io.Writer, func() error, error) {
 			_ = f.Close()
 			return nil, nil, err
 		}
+		warnWindowsOutputACL(file)
 		return f, f.Close, nil
 	case errors.Is(err, os.ErrNotExist):
 		f, err := os.OpenFile(file, os.O_CREATE|os.O_EXCL|os.O_WRONLY, createAPIKeyFileMode)
@@ -146,6 +153,7 @@ func createAPIKeyOutWriter(file string) (io.Writer, func() error, error) {
 			_ = os.Remove(file)
 			return nil, nil, err
 		}
+		warnWindowsOutputACL(file)
 		return f, f.Close, nil
 	default:
 		if runtime.GOOS != "windows" && errors.Is(err, os.ErrPermission) {

--- a/cmd/createapikey.go
+++ b/cmd/createapikey.go
@@ -143,6 +143,7 @@ func createAPIKeyOutWriter(file string) (io.Writer, func() error, error) {
 		}
 		if err := f.Chmod(createAPIKeyFileMode); err != nil {
 			_ = f.Close()
+			_ = os.Remove(file)
 			return nil, nil, err
 		}
 		return f, f.Close, nil

--- a/cmd/createapikey.go
+++ b/cmd/createapikey.go
@@ -86,6 +86,10 @@ type keyStringResult struct {
 
 const createAPIKeyFileMode = 0o600
 
+func ownerOnlyPermissionExample() string {
+	return fmt.Sprintf("%04o", createAPIKeyFileMode)
+}
+
 func warnWindowsOutputACL(file string) {
 	if runtime.GOOS == "windows" {
 		fmt.Fprintf(os.Stderr, "WARNING: Windows does not enforce owner-only access via mode bits for %q; secret file access depends on the directory ACLs\n", file)
@@ -126,11 +130,11 @@ func createAPIKeyOutWriter(file string) (io.Writer, func() error, error) {
 			perms := info.Mode().Perm()
 			if perms&0o077 != 0 {
 				_ = f.Close()
-				return nil, nil, fmt.Errorf("refusing to write secret to %q with permissions %04o; use owner-only permissions with owner write (for example 0600)", file, perms)
+				return nil, nil, fmt.Errorf("refusing to write secret to %q with permissions %04o; use owner-only permissions with owner write (for example %s)", file, perms, ownerOnlyPermissionExample())
 			}
 			if perms&0o200 == 0 {
 				_ = f.Close()
-				return nil, nil, fmt.Errorf("refusing to write secret to %q without owner write permission; use owner-only permissions with owner write (for example 0600)", file)
+				return nil, nil, fmt.Errorf("refusing to write secret to %q without owner write permission; use owner-only permissions with owner write (for example %s)", file, ownerOnlyPermissionExample())
 			}
 		}
 		if err := f.Truncate(0); err != nil {
@@ -160,8 +164,11 @@ func createAPIKeyOutWriter(file string) (io.Writer, func() error, error) {
 			info, statErr := os.Lstat(file)
 			if statErr == nil && info.Mode().IsRegular() {
 				perms := info.Mode().Perm()
-				if perms&0o077 == 0 && perms&0o200 == 0 {
-					return nil, nil, fmt.Errorf("refusing to write secret to %q without owner write permission; use owner-only permissions with owner write (for example 0600)", file)
+				if perms&0o077 != 0 {
+					return nil, nil, fmt.Errorf("refusing to write secret to %q with permissions %04o; use owner-only permissions with owner write (for example %s)", file, perms, ownerOnlyPermissionExample())
+				}
+				if perms&0o200 == 0 {
+					return nil, nil, fmt.Errorf("refusing to write secret to %q without owner write permission; use owner-only permissions with owner write (for example %s)", file, ownerOnlyPermissionExample())
 				}
 			}
 		}

--- a/cmd/createapikey.go
+++ b/cmd/createapikey.go
@@ -99,9 +99,9 @@ func resolveProjectID() string {
 	return ""
 }
 
-func createAPIKeyOutWriter(file string) (io.Writer, func(), error) {
+func createAPIKeyOutWriter(file string) (io.Writer, func() error, error) {
 	if file == "" {
-		return os.Stdout, func() {}, nil
+		return os.Stdout, func() error { return nil }, nil
 	}
 
 	f, err := openExistingCreateAPIKeyFile(file)
@@ -135,7 +135,7 @@ func createAPIKeyOutWriter(file string) (io.Writer, func(), error) {
 			_ = f.Close()
 			return nil, nil, err
 		}
-		return f, func() { f.Close() }, nil
+		return f, f.Close, nil
 	case errors.Is(err, os.ErrNotExist):
 		f, err := os.OpenFile(file, os.O_CREATE|os.O_EXCL|os.O_WRONLY, createAPIKeyFileMode)
 		if err != nil {
@@ -145,7 +145,7 @@ func createAPIKeyOutWriter(file string) (io.Writer, func(), error) {
 			_ = f.Close()
 			return nil, nil, err
 		}
-		return f, func() { f.Close() }, nil
+		return f, f.Close, nil
 	default:
 		if runtime.GOOS != "windows" && errors.Is(err, os.ErrPermission) {
 			info, statErr := os.Lstat(file)
@@ -275,11 +275,20 @@ func runCreateAPIKey(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	defer closer()
+	finishWrite := func(writeErr error) error {
+		closeErr := closer()
+		if writeErr != nil {
+			if closeErr != nil {
+				return errors.Join(writeErr, closeErr)
+			}
+			return writeErr
+		}
+		return closeErr
+	}
 
 	if keyOnly {
 		_, err := fmt.Fprintln(w, ks.KeyString)
-		return err
+		return finishWrite(err)
 	}
 
 	if outputFormat == "txtar" {
@@ -294,9 +303,9 @@ func runCreateAPIKey(cmd *cobra.Command, args []string) error {
 		if targets := extractAPITargets(keyResp); len(targets) > 0 {
 			fmt.Fprintf(w, "Restricted to: %s\n", strings.Join(targets, ", "))
 		}
-		return nil
+		return finishWrite(nil)
 	}
-	return writeFormatted(w, outputFormat, keyResp)
+	return finishWrite(writeFormatted(w, outputFormat, keyResp))
 }
 
 // extractAPITargets returns the service names from the restrictions.apiTargets

--- a/cmd/createapikey.go
+++ b/cmd/createapikey.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"runtime"
 	"strings"
 	"time"
 
@@ -103,14 +104,23 @@ func createAPIKeyOutWriter(file string) (io.Writer, func(), error) {
 		return os.Stdout, func() {}, nil
 	}
 
-	info, err := os.Stat(file)
+	info, err := os.Lstat(file)
 	switch {
 	case err == nil:
+		if info.Mode()&os.ModeSymlink != 0 {
+			return nil, nil, fmt.Errorf("refusing to write secret to symlink %q", file)
+		}
 		if !info.Mode().IsRegular() {
 			return nil, nil, fmt.Errorf("refusing to write secret to non-regular file %q", file)
 		}
-		if info.Mode().Perm()&0o077 != 0 {
-			return nil, nil, fmt.Errorf("refusing to write secret to %q with permissions %04o; use 0600 or stricter", file, info.Mode().Perm())
+		if runtime.GOOS != "windows" {
+			perms := info.Mode().Perm()
+			if perms&0o077 != 0 {
+				return nil, nil, fmt.Errorf("refusing to write secret to %q with permissions %04o; use owner-only permissions with owner write (for example 0600)", file, perms)
+			}
+			if perms&0o200 == 0 {
+				return nil, nil, fmt.Errorf("refusing to write secret to %q without owner write permission; use owner-only permissions with owner write (for example 0600)", file)
+			}
 		}
 		f, err := os.OpenFile(file, os.O_WRONLY|os.O_TRUNC, 0)
 		if err != nil {

--- a/cmd/createapikey_secure_other.go
+++ b/cmd/createapikey_secure_other.go
@@ -2,8 +2,20 @@
 
 package cmd
 
-import "os"
+import (
+	"fmt"
+	"os"
+)
 
 func openExistingCreateAPIKeyFile(file string) (*os.File, error) {
+	// Best-effort symlink rejection for platforms without a no-follow open API
+	// in the Go standard library.
+	info, err := os.Lstat(file)
+	if err != nil {
+		return nil, err
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return nil, fmt.Errorf("refusing to write secret to symlink %q", file)
+	}
 	return os.OpenFile(file, os.O_WRONLY, 0)
 }

--- a/cmd/createapikey_secure_other.go
+++ b/cmd/createapikey_secure_other.go
@@ -1,4 +1,6 @@
-//go:build !(aix || android || darwin || dragonfly || freebsd || illumos || ios || linux || netbsd || openbsd || solaris || windows)
+//go:build !unix && !windows
+
+// This fallback only applies when neither the standard unix nor windows build constraints match.
 
 package cmd
 

--- a/cmd/createapikey_secure_other.go
+++ b/cmd/createapikey_secure_other.go
@@ -1,4 +1,4 @@
-//go:build !unix && !windows
+//go:build !(aix || android || darwin || dragonfly || freebsd || illumos || ios || linux || netbsd || openbsd || solaris || windows)
 
 package cmd
 

--- a/cmd/createapikey_secure_other.go
+++ b/cmd/createapikey_secure_other.go
@@ -11,7 +11,10 @@ import (
 
 func openExistingCreateAPIKeyFile(file string) (*os.File, error) {
 	// Best-effort symlink rejection for platforms without a no-follow open API
-	// in the Go standard library.
+	// in the Go standard library. As on Windows, that leaves an unavoidable
+	// TOCTOU gap between Lstat and OpenFile; createAPIKeyOutWriter still checks
+	// the opened descriptor before reuse so this remains the strongest portable
+	// fallback available here.
 	info, err := os.Lstat(file)
 	if err != nil {
 		return nil, err

--- a/cmd/createapikey_secure_other.go
+++ b/cmd/createapikey_secure_other.go
@@ -1,0 +1,9 @@
+//go:build !unix && !windows
+
+package cmd
+
+import "os"
+
+func openExistingCreateAPIKeyFile(file string) (*os.File, error) {
+	return os.OpenFile(file, os.O_WRONLY, 0)
+}

--- a/cmd/createapikey_secure_unix.go
+++ b/cmd/createapikey_secure_unix.go
@@ -1,4 +1,4 @@
-//go:build unix
+//go:build aix || android || darwin || dragonfly || freebsd || illumos || ios || linux || netbsd || openbsd || solaris
 
 package cmd
 

--- a/cmd/createapikey_secure_unix.go
+++ b/cmd/createapikey_secure_unix.go
@@ -10,7 +10,7 @@ import (
 )
 
 func openExistingCreateAPIKeyFile(file string) (*os.File, error) {
-	fd, err := syscall.Open(file, syscall.O_WRONLY|syscall.O_NOFOLLOW, 0)
+	fd, err := syscall.Open(file, syscall.O_WRONLY|syscall.O_NOFOLLOW|syscall.O_CLOEXEC|syscall.O_NONBLOCK, 0)
 	if err != nil {
 		if errors.Is(err, syscall.ELOOP) {
 			return nil, fmt.Errorf("refusing to write secret to symlink %q", file)

--- a/cmd/createapikey_secure_unix.go
+++ b/cmd/createapikey_secure_unix.go
@@ -1,0 +1,21 @@
+//go:build unix
+
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"syscall"
+)
+
+func openExistingCreateAPIKeyFile(file string) (*os.File, error) {
+	fd, err := syscall.Open(file, syscall.O_WRONLY|syscall.O_NOFOLLOW, 0)
+	if err != nil {
+		if errors.Is(err, syscall.ELOOP) {
+			return nil, fmt.Errorf("refusing to write secret to symlink %q", file)
+		}
+		return nil, err
+	}
+	return os.NewFile(uintptr(fd), file), nil
+}

--- a/cmd/createapikey_secure_unix.go
+++ b/cmd/createapikey_secure_unix.go
@@ -1,6 +1,7 @@
 //go:build unix
 
-// The unix build constraint is a standard Go tag (Go 1.19+) for Unix-like GOOS values.
+// The unix build constraint name was introduced in Go 1.19, but this repository
+// itself targets the toolchain declared in go.mod.
 
 package cmd
 
@@ -15,12 +16,17 @@ func openExistingCreateAPIKeyFile(file string) (*os.File, error) {
 	// Keep the low-level open here: we need no-follow plus non-blocking and
 	// close-on-exec behavior before we can stat/reject the opened descriptor.
 	// os.OpenFile cannot express the same syscall.O_NOFOLLOW/O_CLOEXEC/
-	// O_NONBLOCK combination used here.
+	// O_NONBLOCK combination used here. Clear O_NONBLOCK immediately after a
+	// successful open so the returned descriptor behaves like a normal file.
 	fd, err := syscall.Open(file, syscall.O_WRONLY|syscall.O_NOFOLLOW|syscall.O_CLOEXEC|syscall.O_NONBLOCK, 0)
 	if err != nil {
 		if errors.Is(err, syscall.ELOOP) {
 			return nil, fmt.Errorf("refusing to write secret to symlink %q", file)
 		}
+		return nil, err
+	}
+	if err := syscall.SetNonblock(fd, false); err != nil {
+		_ = syscall.Close(fd)
 		return nil, err
 	}
 	return os.NewFile(uintptr(fd), file), nil

--- a/cmd/createapikey_secure_unix.go
+++ b/cmd/createapikey_secure_unix.go
@@ -1,7 +1,6 @@
 //go:build unix
 
-// The unix build constraint name was introduced in Go 1.19, but this repository
-// itself targets the toolchain declared in go.mod.
+// The unix build constraint selects Unix-like GOOS values in supported toolchains.
 
 package cmd
 

--- a/cmd/createapikey_secure_unix.go
+++ b/cmd/createapikey_secure_unix.go
@@ -14,7 +14,8 @@ import (
 func openExistingCreateAPIKeyFile(file string) (*os.File, error) {
 	// Keep the low-level open here: we need no-follow plus non-blocking and
 	// close-on-exec behavior before we can stat/reject the opened descriptor.
-	// os.OpenFile with os.O_NOFOLLOW cannot express that full combination.
+	// os.OpenFile cannot express the same syscall.O_NOFOLLOW/O_CLOEXEC/
+	// O_NONBLOCK combination used here.
 	fd, err := syscall.Open(file, syscall.O_WRONLY|syscall.O_NOFOLLOW|syscall.O_CLOEXEC|syscall.O_NONBLOCK, 0)
 	if err != nil {
 		if errors.Is(err, syscall.ELOOP) {

--- a/cmd/createapikey_secure_unix.go
+++ b/cmd/createapikey_secure_unix.go
@@ -1,4 +1,6 @@
-//go:build aix || android || darwin || dragonfly || freebsd || illumos || ios || linux || netbsd || openbsd || solaris
+//go:build unix
+
+// The unix build constraint is a standard Go tag (Go 1.19+) for Unix-like GOOS values.
 
 package cmd
 

--- a/cmd/createapikey_secure_unix.go
+++ b/cmd/createapikey_secure_unix.go
@@ -10,6 +10,9 @@ import (
 )
 
 func openExistingCreateAPIKeyFile(file string) (*os.File, error) {
+	// Keep the low-level open here: we need no-follow plus non-blocking and
+	// close-on-exec behavior before we can stat/reject the opened descriptor.
+	// os.OpenFile with os.O_NOFOLLOW cannot express that full combination.
 	fd, err := syscall.Open(file, syscall.O_WRONLY|syscall.O_NOFOLLOW|syscall.O_CLOEXEC|syscall.O_NONBLOCK, 0)
 	if err != nil {
 		if errors.Is(err, syscall.ELOOP) {

--- a/cmd/createapikey_secure_windows.go
+++ b/cmd/createapikey_secure_windows.go
@@ -2,8 +2,20 @@
 
 package cmd
 
-import "os"
+import (
+	"fmt"
+	"os"
+)
 
 func openExistingCreateAPIKeyFile(file string) (*os.File, error) {
+	// Go does not expose a no-follow open on Windows, so this is a best-effort
+	// symlink rejection before opening the existing file for reuse.
+	info, err := os.Lstat(file)
+	if err != nil {
+		return nil, err
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return nil, fmt.Errorf("refusing to write secret to symlink %q", file)
+	}
 	return os.OpenFile(file, os.O_WRONLY, 0)
 }

--- a/cmd/createapikey_secure_windows.go
+++ b/cmd/createapikey_secure_windows.go
@@ -12,7 +12,8 @@ func openExistingCreateAPIKeyFile(file string) (*os.File, error) {
 	// symlink rejection before opening the existing file for reuse. That means
 	// there is still an unavoidable TOCTOU gap between Lstat and OpenFile on
 	// this platform; createAPIKeyOutWriter compensates by validating the opened
-	// descriptor's type and permissions immediately after open.
+	// descriptor's type and Windows-applicable reuse checks immediately after
+	// open.
 	info, err := os.Lstat(file)
 	if err != nil {
 		return nil, err

--- a/cmd/createapikey_secure_windows.go
+++ b/cmd/createapikey_secure_windows.go
@@ -1,0 +1,9 @@
+//go:build windows
+
+package cmd
+
+import "os"
+
+func openExistingCreateAPIKeyFile(file string) (*os.File, error) {
+	return os.OpenFile(file, os.O_WRONLY, 0)
+}

--- a/cmd/createapikey_secure_windows.go
+++ b/cmd/createapikey_secure_windows.go
@@ -9,7 +9,10 @@ import (
 
 func openExistingCreateAPIKeyFile(file string) (*os.File, error) {
 	// Go does not expose a no-follow open on Windows, so this is a best-effort
-	// symlink rejection before opening the existing file for reuse.
+	// symlink rejection before opening the existing file for reuse. That means
+	// there is still an unavoidable TOCTOU gap between Lstat and OpenFile on
+	// this platform; createAPIKeyOutWriter compensates by validating the opened
+	// descriptor's type and permissions immediately after open.
 	info, err := os.Lstat(file)
 	if err != nil {
 		return nil, err

--- a/cmd/createapikey_test.go
+++ b/cmd/createapikey_test.go
@@ -179,6 +179,9 @@ func TestCreateAPIKeyOutWriter_AllowsExistingOwnerOnlyFiles(t *testing.T) {
 	if err := os.WriteFile(path, []byte("old"), createAPIKeyFileMode); err != nil {
 		t.Fatal(err)
 	}
+	if err := os.Chmod(path, createAPIKeyFileMode); err != nil {
+		t.Fatal(err)
+	}
 
 	w, closer, err := createAPIKeyOutWriter(path)
 	if err != nil {

--- a/cmd/createapikey_test.go
+++ b/cmd/createapikey_test.go
@@ -141,7 +141,11 @@ func TestCreateAPIKeyOutWriter_CreatesFilesWithOwnerOnlyPermissions(t *testing.T
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer closer()
+	defer func() {
+		if err := closer(); err != nil {
+			t.Fatal(err)
+		}
+	}()
 
 	if _, err := w.Write([]byte("secret")); err != nil {
 		t.Fatal(err)
@@ -191,7 +195,11 @@ func TestCreateAPIKeyOutWriter_AllowsExistingOwnerOnlyFiles(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer closer()
+	defer func() {
+		if err := closer(); err != nil {
+			t.Fatal(err)
+		}
+	}()
 	if _, err := w.Write([]byte("new")); err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/createapikey_test.go
+++ b/cmd/createapikey_test.go
@@ -160,6 +160,9 @@ func TestCreateAPIKeyOutWriter_RejectsExistingFilesWithBroadPermissions(t *testi
 	if err := os.WriteFile(path, []byte("old"), 0o644); err != nil {
 		t.Fatal(err)
 	}
+	if err := os.Chmod(path, 0o644); err != nil {
+		t.Fatal(err)
+	}
 
 	_, _, err := createAPIKeyOutWriter(path)
 	if err == nil {

--- a/cmd/createapikey_test.go
+++ b/cmd/createapikey_test.go
@@ -184,10 +184,10 @@ func TestCreateAPIKeyOutWriter_AllowsExistingOwnerOnlyFiles(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer closer()
 	if _, err := w.Write([]byte("new")); err != nil {
 		t.Fatal(err)
 	}
-	closer()
 
 	got, err := os.ReadFile(path)
 	if err != nil {

--- a/cmd/createapikey_test.go
+++ b/cmd/createapikey_test.go
@@ -3,6 +3,10 @@ package cmd
 import (
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
 	"testing"
 )
 
@@ -119,5 +123,77 @@ func TestQuotaProjectTransport(t *testing.T) {
 
 	if gotHeader != "my-project" {
 		t.Errorf("x-goog-user-project = %q, want %q", gotHeader, "my-project")
+	}
+}
+
+func TestCreateAPIKeyOutWriter_CreatesFilesWithOwnerOnlyPermissions(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("file permission bits are not reliable on Windows")
+	}
+
+	path := filepath.Join(t.TempDir(), "secret.txt")
+	w, closer, err := createAPIKeyOutWriter(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer closer()
+
+	if _, err := w.Write([]byte("secret")); err != nil {
+		t.Fatal(err)
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := info.Mode().Perm(); got != createAPIKeyFileMode {
+		t.Fatalf("permissions = %04o, want %04o", got, createAPIKeyFileMode)
+	}
+}
+
+func TestCreateAPIKeyOutWriter_RejectsExistingFilesWithBroadPermissions(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("file permission bits are not reliable on Windows")
+	}
+
+	path := filepath.Join(t.TempDir(), "secret.txt")
+	if err := os.WriteFile(path, []byte("old"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, _, err := createAPIKeyOutWriter(path)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "0600") {
+		t.Fatalf("error = %q, want 0600 guidance", err)
+	}
+}
+
+func TestCreateAPIKeyOutWriter_AllowsExistingOwnerOnlyFiles(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("file permission bits are not reliable on Windows")
+	}
+
+	path := filepath.Join(t.TempDir(), "secret.txt")
+	if err := os.WriteFile(path, []byte("old"), createAPIKeyFileMode); err != nil {
+		t.Fatal(err)
+	}
+
+	w, closer, err := createAPIKeyOutWriter(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := w.Write([]byte("new")); err != nil {
+		t.Fatal(err)
+	}
+	closer()
+
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "new" {
+		t.Fatalf("contents = %q, want %q", got, "new")
 	}
 }

--- a/cmd/createapikey_test.go
+++ b/cmd/createapikey_test.go
@@ -197,3 +197,46 @@ func TestCreateAPIKeyOutWriter_AllowsExistingOwnerOnlyFiles(t *testing.T) {
 		t.Fatalf("contents = %q, want %q", got, "new")
 	}
 }
+
+func TestCreateAPIKeyOutWriter_RejectsExistingOwnerOnlyReadOnlyFiles(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("file permission bits are not reliable on Windows")
+	}
+
+	path := filepath.Join(t.TempDir(), "secret.txt")
+	if err := os.WriteFile(path, []byte("old"), 0o400); err != nil {
+		t.Fatal(err)
+	}
+
+	_, _, err := createAPIKeyOutWriter(path)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "owner write") {
+		t.Fatalf("error = %q, want owner write guidance", err)
+	}
+}
+
+func TestCreateAPIKeyOutWriter_RejectsSymlinks(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink setup varies on Windows")
+	}
+
+	dir := t.TempDir()
+	target := filepath.Join(dir, "target.txt")
+	if err := os.WriteFile(target, []byte("old"), createAPIKeyFileMode); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dir, "secret-link.txt")
+	if err := os.Symlink(target, path); err != nil {
+		t.Fatal(err)
+	}
+
+	_, _, err := createAPIKeyOutWriter(path)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "symlink") {
+		t.Fatalf("error = %q, want symlink guidance", err)
+	}
+}

--- a/cmd/createapikey_test.go
+++ b/cmd/createapikey_test.go
@@ -10,6 +10,13 @@ import (
 	"testing"
 )
 
+func requireUnixLikePermissions(t *testing.T) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("file permission bits are not reliable on Windows")
+	}
+}
+
 func TestResolveProjectID(t *testing.T) {
 	// Not parallel: modifies global projectID and env vars.
 	orig := projectID
@@ -127,9 +134,7 @@ func TestQuotaProjectTransport(t *testing.T) {
 }
 
 func TestCreateAPIKeyOutWriter_CreatesFilesWithOwnerOnlyPermissions(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("file permission bits are not reliable on Windows")
-	}
+	requireUnixLikePermissions(t)
 
 	path := filepath.Join(t.TempDir(), "secret.txt")
 	w, closer, err := createAPIKeyOutWriter(path)
@@ -152,9 +157,7 @@ func TestCreateAPIKeyOutWriter_CreatesFilesWithOwnerOnlyPermissions(t *testing.T
 }
 
 func TestCreateAPIKeyOutWriter_RejectsExistingFilesWithBroadPermissions(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("file permission bits are not reliable on Windows")
-	}
+	requireUnixLikePermissions(t)
 
 	path := filepath.Join(t.TempDir(), "secret.txt")
 	if err := os.WriteFile(path, []byte("old"), 0o644); err != nil {
@@ -174,9 +177,7 @@ func TestCreateAPIKeyOutWriter_RejectsExistingFilesWithBroadPermissions(t *testi
 }
 
 func TestCreateAPIKeyOutWriter_AllowsExistingOwnerOnlyFiles(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("file permission bits are not reliable on Windows")
-	}
+	requireUnixLikePermissions(t)
 
 	path := filepath.Join(t.TempDir(), "secret.txt")
 	if err := os.WriteFile(path, []byte("old"), createAPIKeyFileMode); err != nil {
@@ -205,9 +206,7 @@ func TestCreateAPIKeyOutWriter_AllowsExistingOwnerOnlyFiles(t *testing.T) {
 }
 
 func TestCreateAPIKeyOutWriter_RejectsExistingOwnerOnlyReadOnlyFiles(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("file permission bits are not reliable on Windows")
-	}
+	requireUnixLikePermissions(t)
 
 	path := filepath.Join(t.TempDir(), "secret.txt")
 	if err := os.WriteFile(path, []byte("old"), 0o400); err != nil {


### PR DESCRIPTION
## Summary
- add a create-api-key-specific output writer for secret material
- create new secret files with 0600 permissions and reject existing files that are broader than owner-only
- add regression tests for secure file creation and reuse

Closes #5