### PR TITLE
Fix batch-get auth error classification

### DIFF
--- a/cmd/batchget.go
+++ b/cmd/batchget.go
@@ -66,6 +66,9 @@ func (c *apiClient) fetchBatchGet(names []string) ([]Document, error) {
 // Network errors, auth/permission failures, 5xx, and rate-limit exhaustion
 // are not bisectable.
 // Note: 429 is returned as *rateLimitError by checkResponse, not *apiError.
+// Keep this as a conservative allow-list: unknown 4xx responses stay fatal so
+// batch-level request/configuration errors are not rewritten into per-document
+// failures.
 func isBisectable(err error) bool {
 	var ae *apiError
 	if !errors.As(err, &ae) {

--- a/cmd/batchget.go
+++ b/cmd/batchget.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"net/http"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -78,7 +77,7 @@ func isBisectable(err error) bool {
 	case "INVALID_ARGUMENT", "NOT_FOUND":
 		return true
 	}
-	return ae.Code == http.StatusBadRequest || ae.Code == http.StatusNotFound
+	return false
 }
 
 // fetchBatchBisect fetches documents, bisecting on bisectable errors to

--- a/cmd/batchget.go
+++ b/cmd/batchget.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net/http"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -60,14 +61,21 @@ func (c *apiClient) fetchBatchGet(names []string) ([]Document, error) {
 	return resp.Documents, nil
 }
 
-// isBisectable reports whether the error is a client error (4xx) that
-// can be narrowed down by bisecting the request into smaller batches.
-// Network errors, 5xx, and rate-limit exhaustion are not bisectable.
-// Note: 429 is 4xx but is returned as *rateLimitError by checkResponse,
-// not *apiError, so it won't match here.
+// isBisectable reports whether the error is document-specific enough to
+// narrow down by bisecting the request into smaller batches.
+// Network errors, auth/permission failures, 5xx, and rate-limit exhaustion
+// are not bisectable.
+// Note: 429 is returned as *rateLimitError by checkResponse, not *apiError.
 func isBisectable(err error) bool {
 	var ae *apiError
-	return errors.As(err, &ae) && ae.Code >= 400 && ae.Code < 500
+	if !errors.As(err, &ae) {
+		return false
+	}
+	switch ae.Status {
+	case "INVALID_ARGUMENT", "NOT_FOUND":
+		return true
+	}
+	return ae.Code == http.StatusBadRequest || ae.Code == http.StatusNotFound
 }
 
 // fetchBatchBisect fetches documents, bisecting on bisectable errors to

--- a/cmd/batchget.go
+++ b/cmd/batchget.go
@@ -73,6 +73,9 @@ func isBisectable(err error) bool {
 	if !errors.As(err, &ae) {
 		return false
 	}
+	if ae.Code >= 500 {
+		return false
+	}
 	switch ae.Status {
 	case "INVALID_ARGUMENT", "NOT_FOUND":
 		return true

--- a/cmd/batchget.go
+++ b/cmd/batchget.go
@@ -73,7 +73,7 @@ func isBisectable(err error) bool {
 	if !errors.As(err, &ae) {
 		return false
 	}
-	if ae.Code >= 500 {
+	if ae.Code < 400 || ae.Code >= 500 {
 		return false
 	}
 	switch ae.Status {

--- a/cmd/batchget_test.go
+++ b/cmd/batchget_test.go
@@ -343,6 +343,8 @@ func TestIsBisectable_ServerErrorsStayFatal(t *testing.T) {
 		code   int
 		status string
 	}{
+		{name: "missing_http_code", code: 0, status: "NOT_FOUND"},
+		{name: "non_http_client_code", code: 399, status: "INVALID_ARGUMENT"},
 		{name: "not_found_status", code: http.StatusInternalServerError, status: "NOT_FOUND"},
 		{name: "invalid_argument_status", code: http.StatusBadGateway, status: "INVALID_ARGUMENT"},
 	}

--- a/cmd/batchget_test.go
+++ b/cmd/batchget_test.go
@@ -309,6 +309,32 @@ func TestFetchBatchBisect_AuthErrorsAreFatal(t *testing.T) {
 	}
 }
 
+func TestFetchBatchBisect_PlainHTTP404IsFatal(t *testing.T) {
+	t.Parallel()
+
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "404 page not found", http.StatusNotFound)
+	}))
+
+	docs, docErrs, fatal := client.fetchBatchBisect([]string{"documents/a", "documents/b"})
+	if fatal == nil {
+		t.Fatal("expected fatal error, got nil")
+	}
+	var ae *apiError
+	if !errors.As(fatal, &ae) {
+		t.Fatalf("expected *apiError, got %T: %v", fatal, fatal)
+	}
+	if ae.Code != http.StatusNotFound {
+		t.Fatalf("fatal code = %d, want %d", ae.Code, http.StatusNotFound)
+	}
+	if docs != nil {
+		t.Fatalf("docs = %v, want nil", docs)
+	}
+	if docErrs != nil {
+		t.Fatalf("docErrs = %v, want nil", docErrs)
+	}
+}
+
 func TestWriteBatchOutdir(t *testing.T) {
 	t.Parallel()
 

--- a/cmd/batchget_test.go
+++ b/cmd/batchget_test.go
@@ -260,6 +260,55 @@ func TestFetchBatchBisect_NonBisectable(t *testing.T) {
 	}
 }
 
+func TestFetchBatchBisect_AuthErrorsAreFatal(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		code   int
+		status string
+	}{
+		{name: "unauthorized", code: http.StatusUnauthorized, status: "UNAUTHENTICATED"},
+		{name: "forbidden", code: http.StatusForbidden, status: "PERMISSION_DENIED"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(tt.code)
+				json.NewEncoder(w).Encode(map[string]any{
+					"error": map[string]any{
+						"code":    tt.code,
+						"message": "request failed",
+						"status":  tt.status,
+					},
+				})
+			}))
+
+			docs, docErrs, fatal := client.fetchBatchBisect([]string{"documents/a", "documents/b"})
+			if fatal == nil {
+				t.Fatal("expected fatal error, got nil")
+			}
+			var ae *apiError
+			if !errors.As(fatal, &ae) {
+				t.Fatalf("expected *apiError, got %T: %v", fatal, fatal)
+			}
+			if ae.Code != tt.code {
+				t.Fatalf("fatal code = %d, want %d", ae.Code, tt.code)
+			}
+			if docs != nil {
+				t.Fatalf("docs = %v, want nil", docs)
+			}
+			if docErrs != nil {
+				t.Fatalf("docErrs = %v, want nil", docErrs)
+			}
+		})
+	}
+}
+
 func TestWriteBatchOutdir(t *testing.T) {
 	t.Parallel()
 

--- a/cmd/batchget_test.go
+++ b/cmd/batchget_test.go
@@ -335,6 +335,30 @@ func TestFetchBatchBisect_PlainHTTP404IsFatal(t *testing.T) {
 	}
 }
 
+func TestIsBisectable_ServerErrorsStayFatal(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		code   int
+		status string
+	}{
+		{name: "not_found_status", code: http.StatusInternalServerError, status: "NOT_FOUND"},
+		{name: "invalid_argument_status", code: http.StatusBadGateway, status: "INVALID_ARGUMENT"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := &apiError{Code: tt.code, Status: tt.status}
+			if isBisectable(err) {
+				t.Fatalf("isBisectable(%+v) = true, want false", err)
+			}
+		})
+	}
+}
+
 func TestWriteBatchOutdir(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- only bisect document-specific batch-get client errors
- surface auth and permission failures as fatal request-level errors
- add regression coverage for 401 and 403 batch responses

Closes #4