### PR TITLE
Reject non-text get frontmatter output

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ dkcli answer-query "How do I create a Cloud Storage bucket?"
 
 | Flag | Description |
 |------|-------------|
-| `--frontmatter` | Prepend YAML frontmatter to content |
+| `--frontmatter` | Prepend YAML frontmatter to content (`--format=text` only; incompatible with `--size-only`) |
 
 ### `batch-get`
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -215,5 +215,5 @@ Note: `get` and `batch-get` use the GA `v1` document endpoints. `answer-query` s
 | `--max-pages N` | Max pages with `-a` (default 5) |
 | `--filter <expr>` | Filter search results by document metadata |
 | `--outdir <dir>` | Write each doc to separate files (batch-get) |
-| `--frontmatter` | Prepend YAML frontmatter to text output (get, batch-get) |
+| `--frontmatter` | Prepend YAML frontmatter to text output (get, batch-get; `get` does not support it with `--size-only`) |
 | `--key-only` | Print only the API key string (create-api-key) |

--- a/SKILL.md
+++ b/SKILL.md
@@ -215,5 +215,5 @@ Note: `get` and `batch-get` use the GA `v1` document endpoints. `answer-query` s
 | `--max-pages N` | Max pages with `-a` (default 5) |
 | `--filter <expr>` | Filter search results by document metadata |
 | `--outdir <dir>` | Write each doc to separate files (batch-get) |
-| `--frontmatter` | Prepend YAML frontmatter to text output (get, batch-get; `get` does not support it with `--size-only`) |
+| `--frontmatter` | Prepend YAML frontmatter to `--format=text` output (get, batch-get; `get` does not support it with `--size-only`) |
 | `--key-only` | Print only the API key string (create-api-key) |

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -28,7 +28,7 @@ The document name can be specified as:
 }
 
 func init() {
-	getCmd.Flags().BoolVar(&frontmatter, "frontmatter", false, "prepend YAML frontmatter to content")
+	getCmd.Flags().BoolVar(&frontmatter, "frontmatter", false, "prepend YAML frontmatter to content (--format=text only)")
 	getCmd.Flags().BoolVar(&sizeOnly, "size-only", false, "print document size only, suppress content (API calls still occur)")
 	rootCmd.AddCommand(getCmd)
 }
@@ -80,7 +80,7 @@ func formatDocText(doc *Document) string {
 
 func runGet(cmd *cobra.Command, args []string) error {
 	if frontmatter && outputFormat != "text" {
-		return fmt.Errorf("--frontmatter can only be used with text format")
+		return fmt.Errorf("--frontmatter is only supported with --format=text")
 	}
 
 	client, err := newAPIClient(cmd.Context(), authPreferAPIKey)

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -15,6 +15,7 @@ var (
 )
 
 const getFrontmatterTextFormatError = "--frontmatter is only supported with --format=text"
+const getFrontmatterSizeOnlyError = "--frontmatter is not supported with --size-only"
 
 var getCmd = &cobra.Command{
 	Use:   "get <document-name>",
@@ -30,7 +31,7 @@ The document name can be specified as:
 }
 
 func init() {
-	getCmd.Flags().BoolVar(&frontmatter, "frontmatter", false, "prepend YAML frontmatter to content (--format=text only)")
+	getCmd.Flags().BoolVar(&frontmatter, "frontmatter", false, "prepend YAML frontmatter to content (--format=text only; incompatible with --size-only)")
 	getCmd.Flags().BoolVar(&sizeOnly, "size-only", false, "print document size only, suppress content (API calls still occur)")
 	rootCmd.AddCommand(getCmd)
 }
@@ -81,6 +82,9 @@ func formatDocText(doc *Document) string {
 }
 
 func runGet(cmd *cobra.Command, args []string) error {
+	if frontmatter && sizeOnly {
+		return fmt.Errorf(getFrontmatterSizeOnlyError)
+	}
 	if frontmatter && outputFormat != "text" {
 		return fmt.Errorf(getFrontmatterTextFormatError)
 	}

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -79,6 +79,10 @@ func formatDocText(doc *Document) string {
 }
 
 func runGet(cmd *cobra.Command, args []string) error {
+	if frontmatter && outputFormat != "text" {
+		return fmt.Errorf("--frontmatter can only be used with text format")
+	}
+
 	client, err := newAPIClient(cmd.Context(), authPreferAPIKey)
 	if err != nil {
 		return err

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -14,6 +14,8 @@ var (
 	sizeOnly    bool
 )
 
+const getFrontmatterTextFormatError = "--frontmatter is only supported with --format=text"
+
 var getCmd = &cobra.Command{
 	Use:   "get <document-name>",
 	Short: "Get a document with its full Markdown content",
@@ -80,7 +82,7 @@ func formatDocText(doc *Document) string {
 
 func runGet(cmd *cobra.Command, args []string) error {
 	if frontmatter && outputFormat != "text" {
-		return fmt.Errorf("--frontmatter is only supported with --format=text")
+		return fmt.Errorf(getFrontmatterTextFormatError)
 	}
 
 	client, err := newAPIClient(cmd.Context(), authPreferAPIKey)

--- a/cmd/get_test.go
+++ b/cmd/get_test.go
@@ -178,3 +178,29 @@ func TestRunGet_FrontmatterRequiresTextFormat(t *testing.T) {
 		})
 	}
 }
+
+func TestRunGet_FrontmatterRejectsSizeOnly(t *testing.T) {
+	origFrontmatter := frontmatter
+	origSizeOnly := sizeOnly
+	origOutputFormat := outputFormat
+	t.Cleanup(func() {
+		frontmatter = origFrontmatter
+		sizeOnly = origSizeOnly
+		outputFormat = origOutputFormat
+	})
+
+	frontmatter = true
+	sizeOnly = true
+	outputFormat = "text"
+
+	cmd := &cobra.Command{}
+	cmd.SetContext(context.Background())
+
+	err := runGet(cmd, []string{"documents/example.com/page"})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if err.Error() != getFrontmatterSizeOnlyError {
+		t.Fatalf("error = %q, want %q", err.Error(), getFrontmatterSizeOnlyError)
+	}
+}

--- a/cmd/get_test.go
+++ b/cmd/get_test.go
@@ -151,24 +151,30 @@ func TestFetchGet(t *testing.T) {
 }
 
 func TestRunGet_FrontmatterRequiresTextFormat(t *testing.T) {
-	origFrontmatter := frontmatter
-	origOutputFormat := outputFormat
-	t.Cleanup(func() {
-		frontmatter = origFrontmatter
-		outputFormat = origOutputFormat
-	})
+	tests := []string{"json", "jsonl", "yaml", "txtar"}
 
-	frontmatter = true
-	outputFormat = "json"
+	for _, format := range tests {
+		t.Run(format, func(t *testing.T) {
+			origFrontmatter := frontmatter
+			origOutputFormat := outputFormat
+			t.Cleanup(func() {
+				frontmatter = origFrontmatter
+				outputFormat = origOutputFormat
+			})
 
-	cmd := &cobra.Command{}
-	cmd.SetContext(context.Background())
+			frontmatter = true
+			outputFormat = format
 
-	err := runGet(cmd, []string{"documents/example.com/page"})
-	if err == nil {
-		t.Fatal("expected error, got nil")
-	}
-	if err.Error() != "--frontmatter can only be used with text format" {
-		t.Fatalf("error = %q, want %q", err.Error(), "--frontmatter can only be used with text format")
+			cmd := &cobra.Command{}
+			cmd.SetContext(context.Background())
+
+			err := runGet(cmd, []string{"documents/example.com/page"})
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			if err.Error() != "--frontmatter is only supported with --format=text" {
+				t.Fatalf("error = %q, want %q", err.Error(), "--frontmatter is only supported with --format=text")
+			}
+		})
 	}
 }

--- a/cmd/get_test.go
+++ b/cmd/get_test.go
@@ -1,10 +1,13 @@
 package cmd
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"strings"
 	"testing"
+
+	"github.com/spf13/cobra"
 )
 
 func TestNormalizeDocName(t *testing.T) {
@@ -144,5 +147,28 @@ func TestFetchGet(t *testing.T) {
 	}
 	if got.Content != doc.Content {
 		t.Errorf("content = %q, want %q", got.Content, doc.Content)
+	}
+}
+
+func TestRunGet_FrontmatterRequiresTextFormat(t *testing.T) {
+	origFrontmatter := frontmatter
+	origOutputFormat := outputFormat
+	t.Cleanup(func() {
+		frontmatter = origFrontmatter
+		outputFormat = origOutputFormat
+	})
+
+	frontmatter = true
+	outputFormat = "json"
+
+	cmd := &cobra.Command{}
+	cmd.SetContext(context.Background())
+
+	err := runGet(cmd, []string{"documents/example.com/page"})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if err.Error() != "--frontmatter can only be used with text format" {
+		t.Fatalf("error = %q, want %q", err.Error(), "--frontmatter can only be used with text format")
 	}
 }

--- a/cmd/get_test.go
+++ b/cmd/get_test.go
@@ -172,8 +172,8 @@ func TestRunGet_FrontmatterRequiresTextFormat(t *testing.T) {
 			if err == nil {
 				t.Fatal("expected error, got nil")
 			}
-			if err.Error() != "--frontmatter is only supported with --format=text" {
-				t.Fatalf("error = %q, want %q", err.Error(), "--frontmatter is only supported with --format=text")
+			if err.Error() != getFrontmatterTextFormatError {
+				t.Fatalf("error = %q, want %q", err.Error(), getFrontmatterTextFormatError)
 			}
 		})
 	}

--- a/cmd/get_test.go
+++ b/cmd/get_test.go
@@ -156,13 +156,16 @@ func TestRunGet_FrontmatterRequiresTextFormat(t *testing.T) {
 	for _, format := range tests {
 		t.Run(format, func(t *testing.T) {
 			origFrontmatter := frontmatter
+			origSizeOnly := sizeOnly
 			origOutputFormat := outputFormat
 			t.Cleanup(func() {
 				frontmatter = origFrontmatter
+				sizeOnly = origSizeOnly
 				outputFormat = origOutputFormat
 			})
 
 			frontmatter = true
+			sizeOnly = false
 			outputFormat = format
 
 			cmd := &cobra.Command{}


### PR DESCRIPTION
## Summary
- make `get --frontmatter` reject non-text output formats
- align get with the existing batch-get frontmatter behavior
- add regression coverage for `--frontmatter -f json`

Closes #3