### PR TITLE
Surface answer-query citations and refresh docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,13 @@ Uses the `v1alpha:answerQuery` endpoint. It works with an API key, or with ADC i
 dkcli answer-query "How do I create a Cloud Storage bucket?"
 ```
 
-**Note:** This endpoint returns generated text without source URLs or grounding chunks. For verifiable information, prefer the `search` + `get` workflow.
+The text output prints the generated answer followed by source references when
+the API returns them. Structured formats include the full `answer` payload,
+including citation spans and referenced document chunks.
+
+**Note:** This endpoint is a preview surface and is currently limited to 50
+requests per day per project. For full-document verification, prefer the
+`search` + `get` workflow.
 
 ## Global flags
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -18,7 +18,7 @@ description: |
 
 ## dkcli vs Developer Knowledge MCP
 
-If both `dkcli` and the Developer Knowledge MCP tools (`mcp__google-developer-knowledge__*`) are available, **prefer dkcli**. The MCP tools only return full document content with no control over output, while dkcli is a CLI tool that integrates with the shell:
+If both `dkcli` and the Developer Knowledge MCP tools (`mcp__google-developer-knowledge__*`) are available, **prefer dkcli**. The MCP tools are useful for simple direct reads, while dkcli is a CLI tool that integrates with the shell:
 
 - **Output format control** — `-f json`, `-f jsonl`, `-f yaml`, `-f txtar`
 - **Pipe to jq and other tools** — extract, filter, or transform output (e.g., get just the first 500 chars of each document's content)
@@ -42,15 +42,21 @@ dkcli can search and retrieve documents from the following domains only.
 |--------|-------------|
 | adk.dev | Agent Development Kit |
 | ai.google.dev | Google AI (Gemini API, etc.) |
+| antigravity.google | Google Antigravity |
+| cloud.google.com | Google Cloud |
+| dart.dev | Dart |
 | developer.android.com | Android |
 | developer.chrome.com | Chrome |
 | developers.home.google.com | Google Home |
 | developers.google.com | Google developer docs (Workspace APIs, Maps, Ads, etc.) |
-| docs.cloud.google.com | Google Cloud |
 | docs.apigee.com | Apigee |
+| docs.cloud.google.com | Google Cloud |
+| docs.flutter.dev | Flutter |
 | firebase.google.com | Firebase |
 | fuchsia.dev | Fuchsia OS |
+| geminicli.com | Gemini CLI |
 | go.dev | Go |
+| mapsplatform.google.com | Google Maps Platform |
 | web.dev | Web development best practices |
 | www.tensorflow.org | TensorFlow |
 
@@ -147,7 +153,7 @@ dkcli answer-query "How do I create a Cloud Storage bucket?"
 
 This command calls the `v1alpha:answerQuery` endpoint. It works with an API key, or with ADC if a quota project is available.
 
-**Caveat:** The `answer-query` endpoint returns generated text only. It does not include source URLs, grounding chunks, or citations, so you cannot verify which documents the answer is based on. Because of this limitation, **prefer the `search` + `get` workflow for authoritative or verifiable information**. Use `answer-query` only when you need a quick overview and accuracy is less critical.
+**Caveat:** The `answer-query` endpoint returns generated text with citations and references to source document chunks, but it is still a preview endpoint and is currently limited to 50 requests per day per project. For authoritative or full-context verification, **prefer the `search` + `get` workflow**. Use `answer-query` when you need a quick grounded overview, then fetch referenced documents when accuracy matters.
 
 ## Combining with shell tools
 

--- a/cmd/answerquery.go
+++ b/cmd/answerquery.go
@@ -78,6 +78,10 @@ func (c *apiClient) answerQuery(query string) (*answerQueryResponse, error) {
 }
 
 func formatAnswerText(answer *Answer) string {
+	if answer == nil {
+		return ""
+	}
+
 	var sb strings.Builder
 	sb.WriteString(answer.AnswerText)
 	if !strings.HasSuffix(answer.AnswerText, "\n") {

--- a/cmd/answerquery.go
+++ b/cmd/answerquery.go
@@ -81,32 +81,42 @@ func formatAnswerText(answer *Answer) string {
 	if answer == nil {
 		return ""
 	}
+	if answer.AnswerText == "" && len(answer.References) == 0 {
+		return ""
+	}
 
 	var sb strings.Builder
-	sb.WriteString(answer.AnswerText)
-	if !strings.HasSuffix(answer.AnswerText, "\n") {
-		sb.WriteByte('\n')
+	if answer.AnswerText != "" {
+		sb.WriteString(answer.AnswerText)
+		if !strings.HasSuffix(answer.AnswerText, "\n") {
+			sb.WriteByte('\n')
+		}
 	}
 
 	if len(answer.References) == 0 {
 		return sb.String()
 	}
 
-	sb.WriteString("\nReferences:\n")
-	for i := range answer.References {
-		ref := &answer.References[i]
+	if sb.Len() > 0 {
+		sb.WriteByte('\n')
+	}
+	sb.WriteString("References:\n")
+	for i, ref := range answer.References {
 		if ref.DocumentReference == nil || ref.DocumentReference.DocumentChunk == nil {
 			fmt.Fprintf(&sb, "[%d] unknown reference\n", i+1)
 			continue
 		}
 		chunk := ref.DocumentReference.DocumentChunk
 		title := chunk.Parent
-		uri := ""
+		var uri string
 		if chunk.Document != nil {
 			if chunk.Document.Title != "" {
 				title = chunk.Document.Title
 			}
 			uri = chunk.Document.URI
+		}
+		if title == "" {
+			title = "Untitled"
 		}
 		if uri != "" {
 			fmt.Fprintf(&sb, "[%d] %s - %s\n", i+1, title, uri)

--- a/cmd/answerquery.go
+++ b/cmd/answerquery.go
@@ -13,10 +13,10 @@ var answerQueryCmd = &cobra.Command{
 	Short: "Answer a query using grounded generation",
 	Long: `Answer a query using the Developer Knowledge grounded generation API.
 
-This endpoint is currently exposed as v1alpha and returns generated text only.
-It does NOT include source URLs or grounding chunks, so its accuracy cannot be
-verified directly. For authoritative answers, prefer the "search" + "get"
-workflow instead.
+This endpoint is currently exposed as v1alpha and returns generated text with
+citations and references to source document chunks. Text output prints the
+answer followed by source references; structured output includes the full
+answer payload.
 
 If an API key is configured, dkcli uses it. Otherwise it falls back to ADC.`,
 	Args: cobra.MinimumNArgs(1),
@@ -32,7 +32,27 @@ type answerQueryRequest struct {
 }
 
 type Answer struct {
-	AnswerText string `json:"answerText" yaml:"answer_text"`
+	AnswerText string            `json:"answerText" yaml:"answer_text"`
+	Citations  []AnswerCitation  `json:"citations,omitempty" yaml:"citations,omitempty"`
+	References []AnswerReference `json:"references,omitempty" yaml:"references,omitempty"`
+}
+
+type AnswerCitation struct {
+	StartIndex int              `json:"startIndex" yaml:"start_index"`
+	EndIndex   int              `json:"endIndex" yaml:"end_index"`
+	Sources    []CitationSource `json:"sources,omitempty" yaml:"sources,omitempty"`
+}
+
+type CitationSource struct {
+	ReferenceIndex int `json:"referenceIndex" yaml:"reference_index"`
+}
+
+type AnswerReference struct {
+	DocumentReference *DocumentReference `json:"documentReference,omitempty" yaml:"document_reference,omitempty"`
+}
+
+type DocumentReference struct {
+	DocumentChunk *DocumentChunk `json:"documentChunk,omitempty" yaml:"document_chunk,omitempty"`
 }
 
 type answerQueryResponse struct {
@@ -57,6 +77,42 @@ func (c *apiClient) answerQuery(query string) (*answerQueryResponse, error) {
 	return &resp, nil
 }
 
+func formatAnswerText(answer *Answer) string {
+	var sb strings.Builder
+	sb.WriteString(answer.AnswerText)
+	if !strings.HasSuffix(answer.AnswerText, "\n") {
+		sb.WriteByte('\n')
+	}
+
+	if len(answer.References) == 0 {
+		return sb.String()
+	}
+
+	sb.WriteString("\nReferences:\n")
+	for i := range answer.References {
+		ref := &answer.References[i]
+		if ref.DocumentReference == nil || ref.DocumentReference.DocumentChunk == nil {
+			fmt.Fprintf(&sb, "[%d] unknown reference\n", i+1)
+			continue
+		}
+		chunk := ref.DocumentReference.DocumentChunk
+		title := chunk.Parent
+		uri := ""
+		if chunk.Document != nil {
+			if chunk.Document.Title != "" {
+				title = chunk.Document.Title
+			}
+			uri = chunk.Document.URI
+		}
+		if uri != "" {
+			fmt.Fprintf(&sb, "[%d] %s - %s\n", i+1, title, uri)
+		} else {
+			fmt.Fprintf(&sb, "[%d] %s\n", i+1, title)
+		}
+	}
+	return sb.String()
+}
+
 func runAnswerQuery(cmd *cobra.Command, args []string) error {
 	client, err := newAPIClient(cmd.Context(), authPreferAPIKey)
 	if err != nil {
@@ -77,12 +133,10 @@ func runAnswerQuery(cmd *cobra.Command, args []string) error {
 
 	switch outputFormat {
 	case "text":
-		fmt.Fprintln(cmd.ErrOrStderr(), "WARNING: answer-query does not include source URLs or grounding chunks.")
-		fmt.Fprintln(cmd.ErrOrStderr(), "         For verifiable information, run dkcli search, then dkcli get <document-name>.")
-		_, err = fmt.Fprintln(w, resp.Answer.AnswerText)
+		_, err = fmt.Fprint(w, formatAnswerText(&resp.Answer))
 		return err
 	case "txtar":
-		_, err = fmt.Fprint(w, txtarEntry("answer.txt", resp.Answer.AnswerText))
+		_, err = fmt.Fprint(w, txtarEntry("answer.txt", formatAnswerText(&resp.Answer)))
 		return err
 	default:
 		return writeFormatted(w, outputFormat, resp)

--- a/cmd/answerquery_test.go
+++ b/cmd/answerquery_test.go
@@ -161,3 +161,9 @@ func TestRunAnswerQueryTextIncludesReferences(t *testing.T) {
 		}
 	}
 }
+
+func TestFormatAnswerTextNil(t *testing.T) {
+	if got := formatAnswerText(nil); got != "" {
+		t.Fatalf("formatAnswerText(nil) = %q, want empty", got)
+	}
+}

--- a/cmd/answerquery_test.go
+++ b/cmd/answerquery_test.go
@@ -167,3 +167,23 @@ func TestFormatAnswerTextNil(t *testing.T) {
 		t.Fatalf("formatAnswerText(nil) = %q, want empty", got)
 	}
 }
+
+func TestFormatAnswerTextEmpty(t *testing.T) {
+	if got := formatAnswerText(&Answer{}); got != "" {
+		t.Fatalf("formatAnswerText(empty) = %q, want empty", got)
+	}
+}
+
+func TestFormatAnswerTextReferenceFallback(t *testing.T) {
+	got := formatAnswerText(&Answer{
+		References: []AnswerReference{{
+			DocumentReference: &DocumentReference{
+				DocumentChunk: &DocumentChunk{},
+			},
+		}},
+	})
+	want := "References:\n[1] Untitled\n"
+	if got != want {
+		t.Fatalf("formatAnswerText(reference only) = %q, want %q", got, want)
+	}
+}

--- a/cmd/answerquery_test.go
+++ b/cmd/answerquery_test.go
@@ -34,7 +34,26 @@ func TestAnswerQuery(t *testing.T) {
 		}
 
 		json.NewEncoder(w).Encode(answerQueryResponse{
-			Answer: Answer{AnswerText: "dkcli is a CLI for Developer Knowledge."},
+			Answer: Answer{
+				AnswerText: "dkcli is a CLI for Developer Knowledge.",
+				Citations: []AnswerCitation{{
+					StartIndex: 0,
+					EndIndex:   5,
+					Sources:    []CitationSource{{ReferenceIndex: 0}},
+				}},
+				References: []AnswerReference{{
+					DocumentReference: &DocumentReference{
+						DocumentChunk: &DocumentChunk{
+							Parent: "documents/developers.google.com/knowledge/api",
+							ID:     "chunk-1",
+							Document: &Document{
+								Title: "Developer Knowledge API",
+								URI:   "https://developers.google.com/knowledge/api",
+							},
+						},
+					},
+				}},
+			},
 		})
 	}))
 	t.Cleanup(srv.Close)
@@ -52,16 +71,46 @@ func TestAnswerQuery(t *testing.T) {
 	if resp.Answer.AnswerText != "dkcli is a CLI for Developer Knowledge." {
 		t.Fatalf("answer = %q", resp.Answer.AnswerText)
 	}
+	if len(resp.Answer.Citations) != 1 {
+		t.Fatalf("citations = %d, want 1", len(resp.Answer.Citations))
+	}
+	if got := resp.Answer.Citations[0].Sources[0].ReferenceIndex; got != 0 {
+		t.Fatalf("reference index = %d, want 0", got)
+	}
+	if len(resp.Answer.References) != 1 {
+		t.Fatalf("references = %d, want 1", len(resp.Answer.References))
+	}
+	ref := resp.Answer.References[0].DocumentReference
+	if ref == nil || ref.DocumentChunk == nil || ref.DocumentChunk.Document == nil {
+		t.Fatal("expected document reference with document chunk metadata")
+	}
+	if got := ref.DocumentChunk.Document.URI; got != "https://developers.google.com/knowledge/api" {
+		t.Fatalf("reference URI = %q", got)
+	}
 }
 
-func TestRunAnswerQueryWritesWarningToCommandErr(t *testing.T) {
+func TestRunAnswerQueryTextIncludesReferences(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/v1alpha:answerQuery" {
 			http.Error(w, "not found", http.StatusNotFound)
 			return
 		}
 		json.NewEncoder(w).Encode(answerQueryResponse{
-			Answer: Answer{AnswerText: "dkcli is a CLI for Developer Knowledge."},
+			Answer: Answer{
+				AnswerText: "dkcli is a CLI for Developer Knowledge.",
+				References: []AnswerReference{{
+					DocumentReference: &DocumentReference{
+						DocumentChunk: &DocumentChunk{
+							Parent: "documents/developers.google.com/knowledge/api",
+							ID:     "chunk-1",
+							Document: &Document{
+								Title: "Developer Knowledge API",
+								URI:   "https://developers.google.com/knowledge/api",
+							},
+						},
+					},
+				}},
+			},
 		})
 	}))
 	t.Cleanup(srv.Close)
@@ -94,22 +143,21 @@ func TestRunAnswerQueryWritesWarningToCommandErr(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	warning := stderr.String()
-	if !strings.Contains(warning, "does not include source URLs or grounding chunks") {
-		t.Fatalf("warning = %q, want source URL caveat", warning)
-	}
-	if strings.Contains(warning, "|") {
-		t.Fatalf("warning should not imply pipe support: %q", warning)
-	}
-	if !strings.Contains(warning, "dkcli get <document-name>") {
-		t.Fatalf("warning = %q, want get positional argument guidance", warning)
+	if stderr.String() != "" {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
 	}
 
 	data, err := os.ReadFile(outputFile)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if string(data) != "dkcli is a CLI for Developer Knowledge.\n" {
-		t.Fatalf("output = %q", data)
+	for _, want := range []string{
+		"dkcli is a CLI for Developer Knowledge.\n",
+		"\nReferences:\n",
+		"[1] Developer Knowledge API - https://developers.google.com/knowledge/api\n",
+	} {
+		if !strings.Contains(string(data), want) {
+			t.Fatalf("output = %q, want to contain %q", data, want)
+		}
 	}
 }

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -373,7 +373,26 @@ func TestYAMLTagsUseSnakeCase(t *testing.T) {
 			NextPageToken: "next-token",
 		},
 		"answer": answerQueryResponse{
-			Answer: Answer{AnswerText: "grounded"},
+			Answer: Answer{
+				AnswerText: "grounded",
+				Citations: []AnswerCitation{{
+					StartIndex: 0,
+					EndIndex:   8,
+					Sources:    []CitationSource{{ReferenceIndex: 0}},
+				}},
+				References: []AnswerReference{{
+					DocumentReference: &DocumentReference{
+						DocumentChunk: &DocumentChunk{
+							Parent: "documents/example.com/a",
+							ID:     "chunk-1",
+							Document: &Document{
+								DataSource: "example.com",
+								UpdateTime: "2026-04-18T00:00:00Z",
+							},
+						},
+					},
+				}},
+			},
 		},
 	})
 	if err != nil {
@@ -381,12 +400,32 @@ func TestYAMLTagsUseSnakeCase(t *testing.T) {
 	}
 
 	text := string(got)
-	for _, want := range []string{"data_source:", "update_time:", "next_page_token:", "answer_text:"} {
+	for _, want := range []string{
+		"data_source:",
+		"update_time:",
+		"next_page_token:",
+		"answer_text:",
+		"start_index:",
+		"end_index:",
+		"reference_index:",
+		"document_reference:",
+		"document_chunk:",
+	} {
 		if !strings.Contains(text, want) {
 			t.Fatalf("yaml output %q does not contain %q", text, want)
 		}
 	}
-	for _, unwanted := range []string{"dataSource:", "updateTime:", "nextPageToken:", "answerText:"} {
+	for _, unwanted := range []string{
+		"dataSource:",
+		"updateTime:",
+		"nextPageToken:",
+		"answerText:",
+		"startIndex:",
+		"endIndex:",
+		"referenceIndex:",
+		"documentReference:",
+		"documentChunk:",
+	} {
 		if strings.Contains(text, unwanted) {
 			t.Fatalf("yaml output %q unexpectedly contains %q", text, unwanted)
 		}


### PR DESCRIPTION
## Summary
- Surface AnswerQuery citations and references in structured output
- Print answer-query source references in text and txtar output
- Refresh README/SKILL guidance for answer-query and current corpus domains

## Tests
- go test ./...
- go vet ./...
- go build ./...