### PR TITLE
Fix search filter field examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ dkcli search "how to create a Cloud Storage bucket"
 dkcli search -a "Cloud Storage"
 
 # Restrict results to a specific corpus source
-dkcli search --filter 'dataSource = "docs.cloud.google.com"' "BigQuery"
+dkcli search --filter 'data_source = "docs.cloud.google.com"' "BigQuery"
 
 # Fetch more pages
 dkcli search -a --max-pages 20 "Cloud Storage"

--- a/SKILL.md
+++ b/SKILL.md
@@ -85,7 +85,7 @@ dkcli search -a "BigQuery partitioned tables"
 Use `--filter` when you need to stay within a specific data source or time range:
 
 ```bash
-dkcli search --filter 'dataSource = "docs.cloud.google.com"' "BigQuery"
+dkcli search --filter 'data_source = "docs.cloud.google.com"' "BigQuery"
 ```
 
 ### Step 2: Get the full document(s)

--- a/cmd/search_test.go
+++ b/cmd/search_test.go
@@ -86,13 +86,13 @@ func TestFetchSearchPage_WithFilter(t *testing.T) {
 	t.Parallel()
 
 	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if got := r.URL.Query().Get("filter"); got != `dataSource="docs.cloud.google.com"` {
-			t.Errorf("filter = %q, want %q", got, `dataSource="docs.cloud.google.com"`)
+		if got := r.URL.Query().Get("filter"); got != `data_source="docs.cloud.google.com"` {
+			t.Errorf("filter = %q, want %q", got, `data_source="docs.cloud.google.com"`)
 		}
 		json.NewEncoder(w).Encode(&searchResponse{})
 	}))
 
-	_, err := client.fetchSearchPage("test", 0, "", `dataSource="docs.cloud.google.com"`)
+	_, err := client.fetchSearchPage("test", 0, "", `data_source="docs.cloud.google.com"`)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
## Summary
- Update README and SKILL filter examples to use the API field name `data_source`
- Align the search filter unit test fixture with the working API field name

## Verification
- go test ./cmd -run '^TestFetchSearchPage_WithFilter$'\n- go test ./...\n- /private/tmp/dkcli-skill-check -f json search --page-size 1 --filter "data_source = \\"developers.google.com\\"" "Developer Knowledge API"