### PR TITLE
Use developerknowledge-go API helpers

### DIFF
--- a/cmd/batchget.go
+++ b/cmd/batchget.go
@@ -2,14 +2,13 @@ package cmd
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
-	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
 
+	"github.com/apstndb/developerknowledge-go"
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
 )
@@ -35,29 +34,21 @@ func init() {
 	rootCmd.AddCommand(batchGetCmd)
 }
 
-type batchGetResponse struct {
-	Documents []Document `json:"documents" yaml:"documents"`
-}
+type batchGetResponse = dkapi.BatchGetResponse
 
 // fetchBatchGet makes a single batchGet API call for the given document names.
 func (c *apiClient) fetchBatchGet(names []string) ([]Document, error) {
-	params := url.Values{}
-	for _, name := range names {
-		params.Add("names", name)
+	client := &dkapi.Client{
+		BaseURL:       c.baseURL,
+		APIKey:        c.apiKey,
+		HTTPClient:    c.client,
+		Context:       c.requestContext(),
+		Limiter:       c.limiter,
+		Verbose:       c.verbose,
+		VerboseWriter: os.Stderr,
+		MaxRetries:    3,
 	}
-
-	reqURL := c.baseURL + "/documents:batchGet?" + params.Encode()
-
-	body, err := c.doGet(reqURL)
-	if err != nil {
-		return nil, err
-	}
-
-	var resp batchGetResponse
-	if err := json.Unmarshal(body, &resp); err != nil {
-		return nil, err
-	}
-	return resp.Documents, nil
+	return client.BatchGetDocuments(names)
 }
 
 // isBisectable reports whether the error is document-specific enough to
@@ -69,18 +60,7 @@ func (c *apiClient) fetchBatchGet(names []string) ([]Document, error) {
 // batch-level request/configuration errors are not rewritten into per-document
 // failures.
 func isBisectable(err error) bool {
-	var ae *apiError
-	if !errors.As(err, &ae) {
-		return false
-	}
-	if ae.Code < 400 || ae.Code >= 500 {
-		return false
-	}
-	switch ae.Status {
-	case "INVALID_ARGUMENT", "NOT_FOUND":
-		return true
-	}
-	return false
+	return dkapi.IsBisectableDocumentError(err)
 }
 
 // fetchBatchBisect fetches documents, bisecting on bisectable errors to

--- a/cmd/batchget.go
+++ b/cmd/batchget.go
@@ -8,7 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/apstndb/developerknowledge-go"
+	dkapi "github.com/apstndb/developerknowledge-go"
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
 )
@@ -55,7 +55,8 @@ func (c *apiClient) fetchBatchGet(names []string) ([]Document, error) {
 // narrow down by bisecting the request into smaller batches.
 // Network errors, auth/permission failures, 5xx, and rate-limit exhaustion
 // are not bisectable.
-// Note: 429 is returned as *rateLimitError by checkResponse, not *apiError.
+// Note: 429 is returned as *dkapi.RateLimitError by dkapi.CheckResponse, not
+// *dkapi.APIError.
 // Keep this as a conservative allow-list: unknown 4xx responses stay fatal so
 // batch-level request/configuration errors are not rewritten into per-document
 // failures.

--- a/cmd/batchget.go
+++ b/cmd/batchget.go
@@ -46,7 +46,7 @@ func (c *apiClient) fetchBatchGet(names []string) ([]Document, error) {
 		Limiter:       c.limiter,
 		Verbose:       c.verbose,
 		VerboseWriter: os.Stderr,
-		MaxRetries:    3,
+		MaxRetries:    2,
 	}
 	return client.BatchGetDocuments(names)
 }

--- a/cmd/batchget.go
+++ b/cmd/batchget.go
@@ -38,17 +38,7 @@ type batchGetResponse = dkapi.BatchGetResponse
 
 // fetchBatchGet makes a single batchGet API call for the given document names.
 func (c *apiClient) fetchBatchGet(names []string) ([]Document, error) {
-	client := &dkapi.Client{
-		BaseURL:       c.baseURL,
-		APIKey:        c.apiKey,
-		HTTPClient:    c.client,
-		Context:       c.requestContext(),
-		Limiter:       c.limiter,
-		Verbose:       c.verbose,
-		VerboseWriter: os.Stderr,
-		MaxRetries:    2,
-	}
-	return client.BatchGetDocuments(names)
+	return c.newDKClient().BatchGetDocuments(names)
 }
 
 // isBisectable reports whether the error is document-specific enough to

--- a/cmd/batchget_test.go
+++ b/cmd/batchget_test.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"testing"
 
+	dkapi "github.com/apstndb/developerknowledge-go"
 	"github.com/spf13/cobra"
 	"golang.org/x/time/rate"
 )
@@ -193,9 +194,9 @@ func TestFetchBatchGet_APIError(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
-	var ae *apiError
+	var ae *dkapi.APIError
 	if !errors.As(err, &ae) {
-		t.Fatalf("expected *apiError, got %T: %v", err, err)
+		t.Fatalf("expected *dkapi.APIError, got %T: %v", err, err)
 	}
 	if ae.Code != 400 {
 		t.Errorf("error code = %d, want 400", ae.Code)
@@ -367,9 +368,9 @@ func TestFetchBatchBisect_AuthErrorsAreFatal(t *testing.T) {
 			if fatal == nil {
 				t.Fatal("expected fatal error, got nil")
 			}
-			var ae *apiError
+			var ae *dkapi.APIError
 			if !errors.As(fatal, &ae) {
-				t.Fatalf("expected *apiError, got %T: %v", fatal, fatal)
+				t.Fatalf("expected *dkapi.APIError, got %T: %v", fatal, fatal)
 			}
 			if ae.Code != tt.code {
 				t.Fatalf("fatal code = %d, want %d", ae.Code, tt.code)
@@ -395,9 +396,9 @@ func TestFetchBatchBisect_PlainHTTP404IsFatal(t *testing.T) {
 	if fatal == nil {
 		t.Fatal("expected fatal error, got nil")
 	}
-	var ae *apiError
+	var ae *dkapi.APIError
 	if !errors.As(fatal, &ae) {
-		t.Fatalf("expected *apiError, got %T: %v", fatal, fatal)
+		t.Fatalf("expected *dkapi.APIError, got %T: %v", fatal, fatal)
 	}
 	if ae.Code != http.StatusNotFound {
 		t.Fatalf("fatal code = %d, want %d", ae.Code, http.StatusNotFound)
@@ -428,7 +429,7 @@ func TestIsBisectable_ServerErrorsStayFatal(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			err := &apiError{Code: tt.code, Status: tt.status}
+			err := &dkapi.APIError{Code: tt.code, Status: tt.status}
 			if isBisectable(err) {
 				t.Fatalf("isBisectable(%+v) = true, want false", err)
 			}

--- a/cmd/createapikey.go
+++ b/cmd/createapikey.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"time"
 
+	dkapi "github.com/apstndb/developerknowledge-go"
 	"github.com/spf13/cobra"
 )
 
@@ -221,7 +222,7 @@ func doAPIKeysRequest(ctx context.Context, client *http.Client, method, url stri
 	if err != nil {
 		return nil, err
 	}
-	return checkResponse(resp)
+	return dkapi.CheckResponse(resp)
 }
 
 func runCreateAPIKey(cmd *cobra.Command, args []string) error {
@@ -267,7 +268,7 @@ func runCreateAPIKey(cmd *cobra.Command, args []string) error {
 	}
 
 	for !op.Done {
-		if err := sleepContext(opCtx, createAPIKeyPollInterval); err != nil {
+		if err := dkapi.SleepContext(opCtx, createAPIKeyPollInterval); err != nil {
 			if errors.Is(err, context.DeadlineExceeded) {
 				return apiKeyOperationTimeoutError(op.Name)
 			}

--- a/cmd/createapikey_test.go
+++ b/cmd/createapikey_test.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 	"time"
 
+	dkapi "github.com/apstndb/developerknowledge-go"
 	"github.com/spf13/cobra"
 	"golang.org/x/oauth2"
 )
@@ -110,34 +111,6 @@ func TestExtractAPITargets(t *testing.T) {
 				}
 			}
 		})
-	}
-}
-
-func TestQuotaProjectTransport(t *testing.T) {
-	t.Parallel()
-
-	var gotHeader string
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		gotHeader = r.Header.Get("x-goog-user-project")
-		w.WriteHeader(http.StatusOK)
-	}))
-	t.Cleanup(srv.Close)
-
-	client := &http.Client{
-		Transport: &quotaProjectTransport{
-			Base:    http.DefaultTransport,
-			Project: "my-project",
-		},
-	}
-
-	resp, err := client.Get(srv.URL)
-	if err != nil {
-		t.Fatal(err)
-	}
-	resp.Body.Close()
-
-	if gotHeader != "my-project" {
-		t.Errorf("x-goog-user-project = %q, want %q", gotHeader, "my-project")
 	}
 }
 
@@ -267,8 +240,8 @@ func TestNewAPIKeysClient_LeavesClientTimeoutUnset(t *testing.T) {
 
 	orig := defaultTokenSource
 	defaultTokenSource = func(ctx context.Context, scopes ...string) (oauth2.TokenSource, error) {
-		if len(scopes) != 1 || scopes[0] != cloudPlatformScope {
-			t.Fatalf("scopes = %v, want [%q]", scopes, cloudPlatformScope)
+		if len(scopes) != 1 || scopes[0] != dkapi.CloudPlatformScope {
+			t.Fatalf("scopes = %v, want [%q]", scopes, dkapi.CloudPlatformScope)
 		}
 		return oauth2.StaticTokenSource(&oauth2.Token{AccessToken: "test-token"}), nil
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -150,7 +150,7 @@ func (c *apiClient) doAPIRequest(method, url string, body []byte, contentType st
 		Limiter:       c.limiter,
 		Verbose:       c.verbose,
 		VerboseWriter: os.Stderr,
-		MaxRetries:    3,
+		MaxRetries:    2,
 	}
 	return dkClient.DoAPIRequest(method, url, body, contentType)
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -34,11 +34,11 @@ var (
 
 const defaultHTTPTimeout = dkapi.DefaultHTTPTimeout
 
-type authMode int
+type authMode = dkapi.AuthMode
 
 const (
-	authPreferAPIKey authMode = iota
-	authRequireADC
+	authPreferAPIKey = dkapi.AuthPreferAPIKey
+	authRequireADC   = dkapi.AuthRequireADC
 )
 
 var defaultTokenSource = func(ctx context.Context, scopes ...string) (oauth2.TokenSource, error) {
@@ -81,7 +81,7 @@ func apiKeyFromEnv() string {
 
 func newADCHTTPClient(ctx context.Context, mode authMode, timeout time.Duration) (*http.Client, error) {
 	return dkapi.NewADCHTTPClient(ctx, dkapi.AuthConfig{
-		Mode:            dkapi.AuthMode(mode),
+		Mode:            mode,
 		Timeout:         timeout,
 		TokenSource:     defaultTokenSource,
 		CredentialsPath: adcCredentialsPath,
@@ -116,8 +116,9 @@ func newAPIClient(ctx context.Context, mode authMode) (*apiClient, error) {
 // Document represents a Developer Knowledge API document.
 type Document = dkapi.Document
 
-func (c *apiClient) doAPIRequest(method, url string, body []byte, contentType string) ([]byte, error) {
-	dkClient := &dkapi.Client{
+func (c *apiClient) newDKClient() *dkapi.Client {
+	return &dkapi.Client{
+		BaseURL:       c.baseURL,
 		APIKey:        c.apiKey,
 		HTTPClient:    c.client,
 		Context:       c.requestContext(),
@@ -126,7 +127,10 @@ func (c *apiClient) doAPIRequest(method, url string, body []byte, contentType st
 		VerboseWriter: os.Stderr,
 		MaxRetries:    2,
 	}
-	return dkClient.DoAPIRequest(method, url, body, contentType)
+}
+
+func (c *apiClient) doAPIRequest(method, url string, body []byte, contentType string) ([]byte, error) {
+	return c.newDKClient().DoAPIRequest(method, url, body, contentType)
 }
 
 func (c *apiClient) requestContext() context.Context {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/apstndb/developerknowledge-go"
+	dkapi "github.com/apstndb/developerknowledge-go"
 	"github.com/spf13/cobra"
 	"golang.org/x/oauth2"
 	"golang.org/x/time/rate"
@@ -32,7 +32,6 @@ var (
 	answerQueryBaseURL = "https://developerknowledge.googleapis.com/v1alpha"
 )
 
-const cloudPlatformScope = dkapi.CloudPlatformScope
 const defaultHTTPTimeout = dkapi.DefaultHTTPTimeout
 
 type authMode int
@@ -46,13 +45,7 @@ var defaultTokenSource = func(ctx context.Context, scopes ...string) (oauth2.Tok
 	return dkapi.DefaultTokenSource(ctx, scopes...)
 }
 
-type adcCredentialsMetadata = dkapi.ADCCredentialsMetadata
-
 var adcCredentialsPath = dkapi.DefaultCredentialsPath
-
-func defaultADCCredentialsPath(goos, homeDir, appData string) string {
-	return dkapi.DefaultADCCredentialsPath(goos, homeDir, appData)
-}
 
 var rootCmd = &cobra.Command{
 	Use:   "dkcli",
@@ -123,25 +116,6 @@ func newAPIClient(ctx context.Context, mode authMode) (*apiClient, error) {
 // Document represents a Developer Knowledge API document.
 type Document = dkapi.Document
 
-// apiError represents a non-OK HTTP response from the API.
-type apiError = dkapi.APIError
-
-// rateLimitError is returned when the API responds with HTTP 429.
-type rateLimitError = dkapi.RateLimitError
-
-// parseRetryAfter extracts the Retry-After header value as a duration.
-// Returns 0 if the header is absent or unparseable.
-func parseRetryAfter(resp *http.Response) time.Duration {
-	return dkapi.ParseRetryAfter(resp)
-}
-
-// checkResponse reads the response body, closes it, and returns the body bytes.
-// If the status code is not 200, it attempts to parse a Google API error JSON
-// and returns a descriptive error. HTTP 429 returns a *rateLimitError.
-func checkResponse(resp *http.Response) ([]byte, error) {
-	return dkapi.CheckResponse(resp)
-}
-
 func (c *apiClient) doAPIRequest(method, url string, body []byte, contentType string) ([]byte, error) {
 	dkClient := &dkapi.Client{
 		APIKey:        c.apiKey,
@@ -162,10 +136,6 @@ func (c *apiClient) requestContext() context.Context {
 	return context.Background()
 }
 
-func sleepContext(ctx context.Context, wait time.Duration) error {
-	return dkapi.SleepContext(ctx, wait)
-}
-
 func (c *apiClient) doGet(url string) ([]byte, error) {
 	return c.doAPIRequest(http.MethodGet, url, nil, "")
 }
@@ -177,16 +147,6 @@ func (c *apiClient) doJSONPost(url string, body []byte) ([]byte, error) {
 func normalizeDocName(name string) string {
 	return dkapi.NormalizeDocName(name)
 }
-
-func loadADCCredentialsMetadata() adcCredentialsMetadata {
-	return dkapi.LoadADCCredentialsMetadata(adcCredentialsPath)
-}
-
-func resolveQuotaProjectID() (string, adcCredentialsMetadata) {
-	return dkapi.ResolveQuotaProjectID(adcCredentialsPath)
-}
-
-type quotaProjectTransport = dkapi.QuotaProjectTransport
 
 // outWriter returns the writer for command output.
 // If file is non-empty, it opens the file and returns it with a closer.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,24 +1,18 @@
 package cmd
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"net/http"
-	"net/http/httputil"
 	"os"
-	"path/filepath"
-	"runtime"
-	"strconv"
 	"strings"
 	"time"
 
+	"github.com/apstndb/developerknowledge-go"
 	"github.com/spf13/cobra"
 	"golang.org/x/oauth2"
-	"golang.org/x/oauth2/google"
 	"golang.org/x/time/rate"
 	"gopkg.in/yaml.v3"
 )
@@ -38,8 +32,8 @@ var (
 	answerQueryBaseURL = "https://developerknowledge.googleapis.com/v1alpha"
 )
 
-const cloudPlatformScope = "https://www.googleapis.com/auth/cloud-platform"
-const defaultHTTPTimeout = time.Minute
+const cloudPlatformScope = dkapi.CloudPlatformScope
+const defaultHTTPTimeout = dkapi.DefaultHTTPTimeout
 
 type authMode int
 
@@ -49,36 +43,15 @@ const (
 )
 
 var defaultTokenSource = func(ctx context.Context, scopes ...string) (oauth2.TokenSource, error) {
-	return google.DefaultTokenSource(ctx, scopes...)
+	return dkapi.DefaultTokenSource(ctx, scopes...)
 }
 
-type adcCredentialsMetadata struct {
-	Type           string `json:"type"`
-	QuotaProjectID string `json:"quota_project_id"`
-}
+type adcCredentialsMetadata = dkapi.ADCCredentialsMetadata
 
-var adcCredentialsPath = func() string {
-	if path := os.Getenv("GOOGLE_APPLICATION_CREDENTIALS"); path != "" {
-		return path
-	}
-	homeDir, err := os.UserHomeDir()
-	if err != nil {
-		homeDir = ""
-	}
-	return defaultADCCredentialsPath(runtime.GOOS, homeDir, os.Getenv("APPDATA"))
-}
+var adcCredentialsPath = dkapi.DefaultCredentialsPath
 
 func defaultADCCredentialsPath(goos, homeDir, appData string) string {
-	if goos == "windows" {
-		if appData == "" {
-			return ""
-		}
-		return filepath.Join(appData, "gcloud", "application_default_credentials.json")
-	}
-	if homeDir == "" {
-		return ""
-	}
-	return filepath.Join(homeDir, ".config", "gcloud", "application_default_credentials.json")
+	return dkapi.DefaultADCCredentialsPath(goos, homeDir, appData)
 }
 
 var rootCmd = &cobra.Command{
@@ -110,44 +83,16 @@ type apiClient struct {
 }
 
 func apiKeyFromEnv() string {
-	if key := os.Getenv("DEVELOPERKNOWLEDGE_API_KEY"); key != "" {
-		return key
-	}
-	if key := os.Getenv("GOOGLE_API_KEY"); key != "" {
-		return key
-	}
-	return ""
+	return dkapi.APIKeyFromEnv()
 }
 
 func newADCHTTPClient(ctx context.Context, mode authMode, timeout time.Duration) (*http.Client, error) {
-	tokenSource, err := defaultTokenSource(ctx, cloudPlatformScope)
-	if err != nil {
-		if mode == authPreferAPIKey {
-			return nil, fmt.Errorf("set DEVELOPERKNOWLEDGE_API_KEY or GOOGLE_API_KEY, or configure ADC with 'gcloud auth application-default login': %w", err)
-		}
-		return nil, fmt.Errorf("get credentials: %w (run 'gcloud auth application-default login')", err)
-	}
-
-	client := oauth2.NewClient(ctx, tokenSource)
-	if timeout > 0 {
-		client.Timeout = timeout
-	}
-
-	quotaProject, metadata := resolveQuotaProjectID()
-	if quotaProject == "" && metadata.Type == "authorized_user" {
-		return nil, fmt.Errorf("ADC requires a quota project; run 'gcloud auth application-default set-quota-project <project-id>' or set GOOGLE_CLOUD_QUOTA_PROJECT")
-	}
-	if quotaProject != "" {
-		baseTransport := client.Transport
-		if baseTransport == nil {
-			baseTransport = http.DefaultTransport
-		}
-		client.Transport = &quotaProjectTransport{
-			Base:    baseTransport,
-			Project: quotaProject,
-		}
-	}
-	return client, nil
+	return dkapi.NewADCHTTPClient(ctx, dkapi.AuthConfig{
+		Mode:            dkapi.AuthMode(mode),
+		Timeout:         timeout,
+		TokenSource:     defaultTokenSource,
+		CredentialsPath: adcCredentialsPath,
+	})
 }
 
 // newAPIClient creates an apiClient using the global defaults.
@@ -176,150 +121,38 @@ func newAPIClient(ctx context.Context, mode authMode) (*apiClient, error) {
 }
 
 // Document represents a Developer Knowledge API document.
-type Document struct {
-	Name        string `json:"name" yaml:"name"`
-	URI         string `json:"uri" yaml:"uri"`
-	Content     string `json:"content,omitempty" yaml:"content,omitempty"`
-	Description string `json:"description,omitempty" yaml:"description,omitempty"`
-	DataSource  string `json:"dataSource,omitempty" yaml:"data_source,omitempty"`
-	Title       string `json:"title,omitempty" yaml:"title,omitempty"`
-	UpdateTime  string `json:"updateTime,omitempty" yaml:"update_time,omitempty"`
-	View        string `json:"view,omitempty" yaml:"view,omitempty"`
-}
+type Document = dkapi.Document
 
 // apiError represents a non-OK HTTP response from the API.
-type apiError struct {
-	Code    int
-	Status  string
-	Message string
-}
-
-func (e *apiError) Error() string {
-	if e.Status != "" {
-		return fmt.Sprintf("API error %d (%s): %s", e.Code, e.Status, e.Message)
-	}
-	return fmt.Sprintf("HTTP %d: %s", e.Code, e.Message)
-}
+type apiError = dkapi.APIError
 
 // rateLimitError is returned when the API responds with HTTP 429.
-type rateLimitError struct {
-	RetryAfter time.Duration
-}
-
-func (e *rateLimitError) Error() string {
-	if e.RetryAfter > 0 {
-		return fmt.Sprintf("rate limited (retry after %v)", e.RetryAfter)
-	}
-	return "rate limited"
-}
+type rateLimitError = dkapi.RateLimitError
 
 // parseRetryAfter extracts the Retry-After header value as a duration.
 // Returns 0 if the header is absent or unparseable.
 func parseRetryAfter(resp *http.Response) time.Duration {
-	v := resp.Header.Get("Retry-After")
-	if v == "" {
-		return 0
-	}
-	if secs, err := strconv.Atoi(v); err == nil {
-		return time.Duration(secs) * time.Second
-	}
-	return 0
+	return dkapi.ParseRetryAfter(resp)
 }
 
 // checkResponse reads the response body, closes it, and returns the body bytes.
 // If the status code is not 200, it attempts to parse a Google API error JSON
 // and returns a descriptive error. HTTP 429 returns a *rateLimitError.
 func checkResponse(resp *http.Response) ([]byte, error) {
-	body, err := io.ReadAll(resp.Body)
-	resp.Body.Close()
-	if err != nil {
-		return nil, err
-	}
-
-	if resp.StatusCode == http.StatusTooManyRequests {
-		return nil, &rateLimitError{RetryAfter: parseRetryAfter(resp)}
-	}
-
-	if resp.StatusCode != http.StatusOK {
-		var apiErr struct {
-			Error struct {
-				Code    int    `json:"code"`
-				Message string `json:"message"`
-				Status  string `json:"status"`
-			} `json:"error"`
-		}
-		if json.Unmarshal(body, &apiErr) == nil && apiErr.Error.Message != "" {
-			return nil, &apiError{Code: apiErr.Error.Code, Status: apiErr.Error.Status, Message: apiErr.Error.Message}
-		}
-		return nil, &apiError{Code: resp.StatusCode, Message: string(body)}
-	}
-
-	return body, nil
+	return dkapi.CheckResponse(resp)
 }
 
 func (c *apiClient) doAPIRequest(method, url string, body []byte, contentType string) ([]byte, error) {
-	const maxRetries = 3
-	backoff := 1 * time.Second
-	ctx := c.requestContext()
-	var retryErr error
-
-	for attempt := 0; attempt < maxRetries; attempt++ {
-		if err := c.limiter.Wait(ctx); err != nil {
-			return nil, err
-		}
-
-		var requestBody io.Reader
-		if body != nil {
-			requestBody = bytes.NewReader(body)
-		}
-		req, err := http.NewRequestWithContext(ctx, method, url, requestBody)
-		if err != nil {
-			return nil, err
-		}
-		if c.apiKey != "" {
-			req.Header.Set("x-goog-api-key", c.apiKey)
-		}
-		if contentType != "" {
-			req.Header.Set("Content-Type", contentType)
-		}
-
-		resp, err := c.client.Do(req)
-		if err != nil {
-			if resp != nil && resp.Body != nil {
-				io.Copy(io.Discard, resp.Body)
-				resp.Body.Close()
-			}
-			return nil, err
-		}
-
-		if c.verbose {
-			dump, _ := httputil.DumpResponse(resp, false)
-			fmt.Fprintf(os.Stderr, "%s", dump)
-		}
-
-		respBody, err := checkResponse(resp)
-		var rlErr *rateLimitError
-		if errors.As(err, &rlErr) {
-			retryErr = err
-			if attempt == maxRetries-1 {
-				break
-			}
-			wait := backoff
-			if rlErr.RetryAfter > 0 {
-				wait = rlErr.RetryAfter
-			}
-			if c.verbose {
-				fmt.Fprintf(os.Stderr, "Rate limited, retrying after %v...\n", wait)
-			}
-			if err := sleepContext(ctx, wait); err != nil {
-				return nil, err
-			}
-			backoff *= 2
-			continue
-		}
-		return respBody, err
+	dkClient := &dkapi.Client{
+		APIKey:        c.apiKey,
+		HTTPClient:    c.client,
+		Context:       c.requestContext(),
+		Limiter:       c.limiter,
+		Verbose:       c.verbose,
+		VerboseWriter: os.Stderr,
+		MaxRetries:    3,
 	}
-	return nil, retryErr
+	return dkClient.DoAPIRequest(method, url, body, contentType)
 }
 
 func (c *apiClient) requestContext() context.Context {
@@ -330,14 +163,7 @@ func (c *apiClient) requestContext() context.Context {
 }
 
 func sleepContext(ctx context.Context, wait time.Duration) error {
-	timer := time.NewTimer(wait)
-	defer timer.Stop()
-	select {
-	case <-ctx.Done():
-		return ctx.Err()
-	case <-timer.C:
-		return nil
-	}
+	return dkapi.SleepContext(ctx, wait)
 }
 
 func (c *apiClient) doGet(url string) ([]byte, error) {
@@ -349,49 +175,18 @@ func (c *apiClient) doJSONPost(url string, body []byte) ([]byte, error) {
 }
 
 func normalizeDocName(name string) string {
-	name = strings.TrimPrefix(name, "https://")
-	name = strings.TrimPrefix(name, "http://")
-	if !strings.HasPrefix(name, "documents/") {
-		name = "documents/" + name
-	}
-	return name
+	return dkapi.NormalizeDocName(name)
 }
 
 func loadADCCredentialsMetadata() adcCredentialsMetadata {
-	path := adcCredentialsPath()
-	if path == "" {
-		return adcCredentialsMetadata{}
-	}
-	data, err := os.ReadFile(path)
-	if err != nil {
-		return adcCredentialsMetadata{}
-	}
-	var cfg adcCredentialsMetadata
-	if err := json.Unmarshal(data, &cfg); err != nil {
-		return adcCredentialsMetadata{}
-	}
-	return cfg
+	return dkapi.LoadADCCredentialsMetadata(adcCredentialsPath)
 }
 
 func resolveQuotaProjectID() (string, adcCredentialsMetadata) {
-	if p := os.Getenv("GOOGLE_CLOUD_QUOTA_PROJECT"); p != "" {
-		return p, adcCredentialsMetadata{}
-	}
-
-	cfg := loadADCCredentialsMetadata()
-	return cfg.QuotaProjectID, cfg
+	return dkapi.ResolveQuotaProjectID(adcCredentialsPath)
 }
 
-type quotaProjectTransport struct {
-	Base    http.RoundTripper
-	Project string
-}
-
-func (t *quotaProjectTransport) RoundTrip(req *http.Request) (*http.Response, error) {
-	req = req.Clone(req.Context())
-	req.Header.Set("x-goog-user-project", t.Project)
-	return t.Base.RoundTrip(req)
-}
+type quotaProjectTransport = dkapi.QuotaProjectTransport
 
 // outWriter returns the writer for command output.
 // If file is non-empty, it opens the file and returns it with a closer.

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 	"time"
 
+	dkapi "github.com/apstndb/developerknowledge-go"
 	"golang.org/x/oauth2"
 	"golang.org/x/time/rate"
 	"gopkg.in/yaml.v3"
@@ -59,8 +60,8 @@ func TestNewAPIClient_FallsBackToADC(t *testing.T) {
 
 	orig := defaultTokenSource
 	defaultTokenSource = func(ctx context.Context, scopes ...string) (oauth2.TokenSource, error) {
-		if len(scopes) != 1 || scopes[0] != cloudPlatformScope {
-			t.Fatalf("scopes = %v, want [%q]", scopes, cloudPlatformScope)
+		if len(scopes) != 1 || scopes[0] != dkapi.CloudPlatformScope {
+			t.Fatalf("scopes = %v, want [%q]", scopes, dkapi.CloudPlatformScope)
 		}
 		return oauth2.StaticTokenSource(&oauth2.Token{AccessToken: "test-token"}), nil
 	}
@@ -110,83 +111,6 @@ func TestNewAPIClient_SetsQuotaProjectHeader(t *testing.T) {
 	resp.Body.Close()
 	if gotQuota != "quota-project" {
 		t.Fatalf("x-goog-user-project = %q, want %q", gotQuota, "quota-project")
-	}
-}
-
-func TestResolveQuotaProjectID(t *testing.T) {
-	t.Setenv("GOOGLE_CLOUD_QUOTA_PROJECT", "quota-project")
-	got, _ := resolveQuotaProjectID()
-	if got != "quota-project" {
-		t.Fatalf("got %q, want %q", got, "quota-project")
-	}
-}
-
-func TestResolveQuotaProjectIDFromADCFile(t *testing.T) {
-	t.Setenv("GOOGLE_CLOUD_QUOTA_PROJECT", "")
-
-	dir := t.TempDir()
-	path := filepath.Join(dir, "adc.json")
-	data, err := json.Marshal(map[string]string{"quota_project_id": "from-file"})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(path, data, 0o644); err != nil {
-		t.Fatal(err)
-	}
-
-	orig := adcCredentialsPath
-	adcCredentialsPath = func() string { return path }
-	t.Cleanup(func() { adcCredentialsPath = orig })
-
-	got, _ := resolveQuotaProjectID()
-	if got != "from-file" {
-		t.Fatalf("got %q, want %q", got, "from-file")
-	}
-}
-
-func TestDefaultADCCredentialsPath(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		name    string
-		goos    string
-		homeDir string
-		appData string
-		want    string
-	}{
-		{
-			name:    "darwin uses xdg-compatible gcloud path",
-			goos:    "darwin",
-			homeDir: "/Users/alice",
-			want:    filepath.Join("/Users/alice", ".config", "gcloud", "application_default_credentials.json"),
-		},
-		{
-			name:    "linux uses xdg-compatible gcloud path",
-			goos:    "linux",
-			homeDir: "/home/alice",
-			want:    filepath.Join("/home/alice", ".config", "gcloud", "application_default_credentials.json"),
-		},
-		{
-			name:    "windows uses APPDATA",
-			goos:    "windows",
-			appData: filepath.Join("C:", "Users", "alice", "AppData", "Roaming"),
-			want:    filepath.Join("C:", "Users", "alice", "AppData", "Roaming", "gcloud", "application_default_credentials.json"),
-		},
-		{
-			name: "windows without APPDATA returns empty",
-			goos: "windows",
-			want: "",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-			got := defaultADCCredentialsPath(tt.goos, tt.homeDir, tt.appData)
-			if got != tt.want {
-				t.Fatalf("defaultADCCredentialsPath(%q, %q, %q) = %q, want %q", tt.goos, tt.homeDir, tt.appData, got, tt.want)
-			}
-		})
 	}
 }
 

--- a/cmd/search.go
+++ b/cmd/search.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/apstndb/developerknowledge-go"
+	dkapi "github.com/apstndb/developerknowledge-go"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/search.go
+++ b/cmd/search.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/apstndb/developerknowledge-go"
 	"github.com/spf13/cobra"
 )
 
@@ -38,12 +39,7 @@ func init() {
 }
 
 // DocumentChunk represents a search result chunk.
-type DocumentChunk struct {
-	Parent   string    `json:"parent" yaml:"parent"`
-	ID       string    `json:"id" yaml:"id"`
-	Content  string    `json:"content" yaml:"content"`
-	Document *Document `json:"document,omitempty" yaml:"document,omitempty"`
-}
+type DocumentChunk = dkapi.DocumentChunk
 
 type searchResponse struct {
 	Results       []DocumentChunk `json:"results" yaml:"results"`

--- a/cmd/search_test.go
+++ b/cmd/search_test.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"net/http"
 	"testing"
+
+	dkapi "github.com/apstndb/developerknowledge-go"
 )
 
 func TestFetchSearchPage(t *testing.T) {
@@ -117,9 +119,9 @@ func TestFetchSearchPage_APIError(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
-	var ae *apiError
+	var ae *dkapi.APIError
 	if !errors.As(err, &ae) {
-		t.Fatalf("expected *apiError, got %T: %v", err, err)
+		t.Fatalf("expected *dkapi.APIError, got %T: %v", err, err)
 	}
 	if ae.Code != 400 {
 		t.Errorf("code = %d, want 400", ae.Code)

--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,10 @@ module github.com/apstndb/dkcli
 go 1.24.0
 
 require (
+	github.com/apstndb/developerknowledge-go v0.1.0
 	github.com/spf13/cobra v1.8.1
 	golang.org/x/oauth2 v0.25.0
+	golang.org/x/time v0.14.0
 	gopkg.in/yaml.v3 v3.0.1
 )
 
@@ -12,5 +14,4 @@ require (
 	cloud.google.com/go/compute/metadata v0.3.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
-	golang.org/x/time v0.14.0 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/apstndb/dkcli
 go 1.24.0
 
 require (
-	github.com/apstndb/developerknowledge-go v0.1.1
+	github.com/apstndb/developerknowledge-go v0.1.2
 	github.com/spf13/cobra v1.8.1
 	golang.org/x/oauth2 v0.25.0
 	golang.org/x/time v0.14.0

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/apstndb/dkcli
 go 1.24.0
 
 require (
-	github.com/apstndb/developerknowledge-go v0.1.0
+	github.com/apstndb/developerknowledge-go v0.1.1
 	github.com/spf13/cobra v1.8.1
 	golang.org/x/oauth2 v0.25.0
 	golang.org/x/time v0.14.0

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 cloud.google.com/go/compute/metadata v0.3.0 h1:Tz+eQXMEqDIKRsmY3cHTL6FVaynIjX2QxYC4trgAKZc=
 cloud.google.com/go/compute/metadata v0.3.0/go.mod h1:zFmK7XCadkQkj6TtorcaGlCW1hT1fIilQDwofLpJ20k=
-github.com/apstndb/developerknowledge-go v0.1.1 h1:5sL7fPVV464Q1to31DdZQCnG4SAIESYRs7+m1J9zUqY=
-github.com/apstndb/developerknowledge-go v0.1.1/go.mod h1:SkrYUXrudPdwg//GnGSnLsjYilMI+9n2+TGUuHo/CcE=
+github.com/apstndb/developerknowledge-go v0.1.2 h1:ejpPuozEUEl6W7kCAeK3N9OzwfZEqSuTABckOSsNA9A=
+github.com/apstndb/developerknowledge-go v0.1.2/go.mod h1:SkrYUXrudPdwg//GnGSnLsjYilMI+9n2+TGUuHo/CcE=
 github.com/cpuguy83/go-md2man/v2 v2.0.4/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 cloud.google.com/go/compute/metadata v0.3.0 h1:Tz+eQXMEqDIKRsmY3cHTL6FVaynIjX2QxYC4trgAKZc=
 cloud.google.com/go/compute/metadata v0.3.0/go.mod h1:zFmK7XCadkQkj6TtorcaGlCW1hT1fIilQDwofLpJ20k=
+github.com/apstndb/developerknowledge-go v0.1.0 h1:hM9hg5pueJ3xvN3ZqLbjuN7sz+YsPVHQGL++z1r5UCE=
+github.com/apstndb/developerknowledge-go v0.1.0/go.mod h1:SkrYUXrudPdwg//GnGSnLsjYilMI+9n2+TGUuHo/CcE=
 github.com/cpuguy83/go-md2man/v2 v2.0.4/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 cloud.google.com/go/compute/metadata v0.3.0 h1:Tz+eQXMEqDIKRsmY3cHTL6FVaynIjX2QxYC4trgAKZc=
 cloud.google.com/go/compute/metadata v0.3.0/go.mod h1:zFmK7XCadkQkj6TtorcaGlCW1hT1fIilQDwofLpJ20k=
-github.com/apstndb/developerknowledge-go v0.1.0 h1:hM9hg5pueJ3xvN3ZqLbjuN7sz+YsPVHQGL++z1r5UCE=
-github.com/apstndb/developerknowledge-go v0.1.0/go.mod h1:SkrYUXrudPdwg//GnGSnLsjYilMI+9n2+TGUuHo/CcE=
+github.com/apstndb/developerknowledge-go v0.1.1 h1:5sL7fPVV464Q1to31DdZQCnG4SAIESYRs7+m1J9zUqY=
+github.com/apstndb/developerknowledge-go v0.1.1/go.mod h1:SkrYUXrudPdwg//GnGSnLsjYilMI+9n2+TGUuHo/CcE=
 github.com/cpuguy83/go-md2man/v2 v2.0.4/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=


### PR DESCRIPTION
## Summary
- replace local Developer Knowledge API auth/request/error helpers with github.com/apstndb/developerknowledge-go v0.1.2
- keep CLI retry, limiter, and output behavior in dkcli while sharing API primitives
- reuse shared Document, DocumentChunk, batchGet, and conservative batch-bisection error classification
- preserve the existing total attempt count after shared MaxRetries semantics were clarified

## Tests
- go test ./...
- go build ./...
- go vet ./...
- git diff --check
- review-router copilot-gpt-5.4: No material issues
