### PR TITLE
Migrate to context-first developerknowledge-go API (v0.2.0)

### DIFF
--- a/cmd/batchget.go
+++ b/cmd/batchget.go
@@ -38,7 +38,7 @@ type batchGetResponse = dkapi.BatchGetResponse
 
 // fetchBatchGet makes a single batchGet API call for the given document names.
 func (c *apiClient) fetchBatchGet(names []string) ([]Document, error) {
-	return c.newDKClient().BatchGetDocuments(names)
+	return c.newDKClient().BatchGetDocuments(c.requestContext(), names)
 }
 
 // isBisectable reports whether the error is document-specific enough to

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -121,7 +121,6 @@ func (c *apiClient) newDKClient() *dkapi.Client {
 		BaseURL:       c.baseURL,
 		APIKey:        c.apiKey,
 		HTTPClient:    c.client,
-		Context:       c.requestContext(),
 		Limiter:       c.limiter,
 		Verbose:       c.verbose,
 		VerboseWriter: os.Stderr,
@@ -130,7 +129,7 @@ func (c *apiClient) newDKClient() *dkapi.Client {
 }
 
 func (c *apiClient) doAPIRequest(method, url string, body []byte, contentType string) ([]byte, error) {
-	return c.newDKClient().DoAPIRequest(method, url, body, contentType)
+	return c.newDKClient().DoAPIRequest(c.requestContext(), method, url, body, contentType)
 }
 
 func (c *apiClient) requestContext() context.Context {

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/apstndb/dkcli
 go 1.24.0
 
 require (
-	github.com/apstndb/developerknowledge-go v0.1.2
+	github.com/apstndb/developerknowledge-go v0.1.3-0.20260705140616-7dd29210f40a
 	github.com/spf13/cobra v1.8.1
 	golang.org/x/oauth2 v0.25.0
 	golang.org/x/time v0.14.0

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 cloud.google.com/go/compute/metadata v0.3.0 h1:Tz+eQXMEqDIKRsmY3cHTL6FVaynIjX2QxYC4trgAKZc=
 cloud.google.com/go/compute/metadata v0.3.0/go.mod h1:zFmK7XCadkQkj6TtorcaGlCW1hT1fIilQDwofLpJ20k=
-github.com/apstndb/developerknowledge-go v0.1.2 h1:ejpPuozEUEl6W7kCAeK3N9OzwfZEqSuTABckOSsNA9A=
-github.com/apstndb/developerknowledge-go v0.1.2/go.mod h1:SkrYUXrudPdwg//GnGSnLsjYilMI+9n2+TGUuHo/CcE=
+github.com/apstndb/developerknowledge-go v0.1.3-0.20260705140616-7dd29210f40a h1:n70M+x0GkOsz+0FgTjF6GbcyComh78rWk2XPXFKf//M=
+github.com/apstndb/developerknowledge-go v0.1.3-0.20260705140616-7dd29210f40a/go.mod h1:SkrYUXrudPdwg//GnGSnLsjYilMI+9n2+TGUuHo/CcE=
 github.com/cpuguy83/go-md2man/v2 v2.0.4/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=


### PR DESCRIPTION
## Summary
- Bump `github.com/apstndb/developerknowledge-go` to the v0.2.0 main-line pseudo-version (`v0.1.3-0.20260705140616-7dd29210f40a`) until the `v0.2.0` tag is published
- Pass request context into `DoAPIRequest` and `BatchGetDocuments` instead of setting `Client.Context`

Part of apstndb/developerknowledge-go#9.

## Test plan
- [x] `go test -race ./...`


Made with [Cursor](https://cursor.com)