### PR TITLE
Tighten CLI validation and lifecycle handling

### DIFF
--- a/cmd/answerquery.go
+++ b/cmd/answerquery.go
@@ -143,16 +143,15 @@ func runAnswerQuery(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	defer closer()
 
 	switch outputFormat {
 	case "text":
 		_, err = fmt.Fprint(w, formatAnswerText(&resp.Answer))
-		return err
+		return finishOutput(err, closer)
 	case "txtar":
 		_, err = fmt.Fprint(w, txtarEntry("answer.txt", formatAnswerText(&resp.Answer)))
-		return err
+		return finishOutput(err, closer)
 	default:
-		return writeFormatted(w, outputFormat, resp)
+		return finishOutput(writeFormatted(w, outputFormat, resp), closer)
 	}
 }

--- a/cmd/batchget.go
+++ b/cmd/batchget.go
@@ -317,11 +317,11 @@ func runBatchGet(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			return err
 		}
-		defer closer()
 		outputErr = printBatchOutput(w, docs, outputFormat, batchFrontmatter)
 		if outputErr == nil && outputFormat == "text" {
 			printDocsSummary(cmd.ErrOrStderr(), docs)
 		}
+		outputErr = finishOutput(outputErr, closer)
 	}
 	if outputErr != nil {
 		return outputErr

--- a/cmd/batchget.go
+++ b/cmd/batchget.go
@@ -318,10 +318,10 @@ func runBatchGet(cmd *cobra.Command, args []string) error {
 			return err
 		}
 		outputErr = printBatchOutput(w, docs, outputFormat, batchFrontmatter)
+		outputErr = finishOutput(outputErr, closer)
 		if outputErr == nil && outputFormat == "text" {
 			printDocsSummary(cmd.ErrOrStderr(), docs)
 		}
-		outputErr = finishOutput(outputErr, closer)
 	}
 	if outputErr != nil {
 		return outputErr

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -2,7 +2,7 @@ package cmd
 
 import (
 	"encoding/json"
-	"fmt"
+	"errors"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -83,10 +83,10 @@ func formatDocText(doc *Document) string {
 
 func runGet(cmd *cobra.Command, args []string) error {
 	if frontmatter && sizeOnly {
-		return fmt.Errorf(getFrontmatterSizeOnlyError)
+		return errors.New(getFrontmatterSizeOnlyError)
 	}
 	if frontmatter && outputFormat != "text" {
-		return fmt.Errorf(getFrontmatterTextFormatError)
+		return errors.New(getFrontmatterTextFormatError)
 	}
 
 	client, err := newAPIClient(cmd.Context(), authPreferAPIKey)
@@ -117,26 +117,25 @@ func runGet(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	defer closer()
 
 	if frontmatter {
 		s, err := formatDocWithFrontmatter(&doc)
 		if err != nil {
-			return err
+			return finishOutput(err, closer)
 		}
-		_, err = fmt.Fprint(w, s)
-		return err
+		_, err = w.Write([]byte(s))
+		return finishOutput(err, closer)
 	}
 
 	switch outputFormat {
 	case "text":
-		_, err := fmt.Fprint(w, formatDocText(&doc))
-		return err
+		_, err := w.Write([]byte(formatDocText(&doc)))
+		return finishOutput(err, closer)
 	case "txtar":
-		_, err := fmt.Fprint(w, txtarEntry(doc.Name, doc.Content))
-		return err
+		_, err := w.Write([]byte(txtarEntry(doc.Name, doc.Content)))
+		return finishOutput(err, closer)
 	default:
-		return writeFormatted(w, outputFormat, doc)
+		return finishOutput(writeFormatted(w, outputFormat, doc), closer)
 	}
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -3,10 +3,12 @@ package cmd
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
 	"os"
+	"runtime/debug"
 	"strings"
 	"time"
 
@@ -25,6 +27,8 @@ var (
 	outputFile   string
 	verbose      bool
 )
+
+var version = "dev"
 
 var (
 	searchBaseURL = "https://developerknowledge.googleapis.com/v1"
@@ -48,12 +52,20 @@ var defaultTokenSource = func(ctx context.Context, scopes ...string) (oauth2.Tok
 var adcCredentialsPath = dkapi.DefaultCredentialsPath
 
 var rootCmd = &cobra.Command{
-	Use:   "dkcli",
-	Short: "CLI client for Google Developer Knowledge API",
+	Use:     "dkcli",
+	Short:   "CLI client for Google Developer Knowledge API",
+	Version: commandVersion(),
+	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+		return validateOutputFormat(outputFormat)
+	},
 }
 
 func Execute() {
-	if err := rootCmd.Execute(); err != nil {
+	ExecuteContext(context.Background())
+}
+
+func ExecuteContext(ctx context.Context) {
+	if err := rootCmd.ExecuteContext(ctx); err != nil {
 		os.Exit(1)
 	}
 }
@@ -63,6 +75,26 @@ func init() {
 	rootCmd.PersistentFlags().StringVarP(&outputFile, "output", "o", "", "write output to file")
 	rootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "dump response headers to stderr")
 	rootCmd.SilenceUsage = true
+}
+
+func commandVersion() string {
+	if version != "" && version != "dev" {
+		return version
+	}
+	info, ok := debug.ReadBuildInfo()
+	if ok && info.Main.Version != "" && info.Main.Version != "(devel)" {
+		return info.Main.Version
+	}
+	return version
+}
+
+func validateOutputFormat(format string) error {
+	switch format {
+	case "text", "json", "jsonl", "yaml", "txtar":
+		return nil
+	default:
+		return fmt.Errorf("unknown format: %s", format)
+	}
 }
 
 // apiClient holds the configuration for making API requests.
@@ -155,15 +187,26 @@ func normalizeDocName(name string) string {
 // outWriter returns the writer for command output.
 // If file is non-empty, it opens the file and returns it with a closer.
 // Otherwise it returns stdout.
-func outWriter(file string) (io.Writer, func(), error) {
+func outWriter(file string) (io.Writer, func() error, error) {
 	if file == "" {
-		return os.Stdout, func() {}, nil
+		return os.Stdout, func() error { return nil }, nil
 	}
 	f, err := os.Create(file)
 	if err != nil {
 		return nil, nil, err
 	}
-	return f, func() { f.Close() }, nil
+	return f, f.Close, nil
+}
+
+func finishOutput(writeErr error, close func() error) error {
+	closeErr := close()
+	if writeErr != nil {
+		if closeErr != nil {
+			return errors.Join(writeErr, closeErr)
+		}
+		return writeErr
+	}
+	return closeErr
 }
 
 // writeFormatted encodes v in the given format to w.

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -26,6 +26,46 @@ func (f roundTripperFunc) RoundTrip(req *http.Request) (*http.Response, error) {
 	return f(req)
 }
 
+func TestValidateOutputFormat(t *testing.T) {
+	for _, format := range []string{"text", "json", "jsonl", "yaml", "txtar"} {
+		t.Run(format, func(t *testing.T) {
+			if err := validateOutputFormat(format); err != nil {
+				t.Fatalf("validateOutputFormat(%q) = %v, want nil", format, err)
+			}
+		})
+	}
+
+	err := validateOutputFormat("xml")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "unknown format: xml") {
+		t.Fatalf("error = %q, want unknown format message", err)
+	}
+}
+
+func TestFinishOutputReturnsCloseError(t *testing.T) {
+	closeErr := errors.New("close failed")
+
+	err := finishOutput(nil, func() error { return closeErr })
+	if !errors.Is(err, closeErr) {
+		t.Fatalf("finishOutput(nil, closeErr) = %v, want closeErr", err)
+	}
+}
+
+func TestFinishOutputJoinsWriteAndCloseErrors(t *testing.T) {
+	writeErr := errors.New("write failed")
+	closeErr := errors.New("close failed")
+
+	err := finishOutput(writeErr, func() error { return closeErr })
+	if !errors.Is(err, writeErr) {
+		t.Fatalf("finishOutput error = %v, want writeErr", err)
+	}
+	if !errors.Is(err, closeErr) {
+		t.Fatalf("finishOutput error = %v, want closeErr", err)
+	}
+}
+
 func TestNewAPIClient_PrefersAPIKey(t *testing.T) {
 	t.Setenv("DEVELOPERKNOWLEDGE_API_KEY", "api-key")
 

--- a/cmd/search.go
+++ b/cmd/search.go
@@ -26,7 +26,10 @@ var searchCmd = &cobra.Command{
 	Use:   "search <query>...",
 	Short: "Search developer documentation chunks",
 	Args:  cobra.MinimumNArgs(1),
-	RunE:  runSearch,
+	PreRunE: func(cmd *cobra.Command, args []string) error {
+		return validateSearchFlags(pageSize, maxPages)
+	},
+	RunE: runSearch,
 }
 
 func init() {
@@ -117,6 +120,16 @@ func (c *apiClient) fetchSearchPage(query string, size int, token, filter string
 	return &resp, nil
 }
 
+func validateSearchFlags(size, pages int) error {
+	if size < 0 || size > 20 {
+		return fmt.Errorf("--page-size must be between 0 and 20")
+	}
+	if pages < 0 {
+		return fmt.Errorf("--max-pages must be greater than or equal to 0")
+	}
+	return nil
+}
+
 func runSearch(cmd *cobra.Command, args []string) error {
 	client, err := newAPIClient(cmd.Context(), authPreferAPIKey)
 	if err != nil {
@@ -134,10 +147,9 @@ func runSearch(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	defer closer()
 
 	if outputFormat == "jsonl" {
-		return runSearchJSONL(w, client, query)
+		return finishOutput(runSearchJSONL(w, client, query), closer)
 	}
 
 	var allResults searchResponse
@@ -148,7 +160,7 @@ func runSearch(cmd *cobra.Command, args []string) error {
 	for {
 		resp, err := client.fetchSearchPage(query, pageSize, token, searchFilter)
 		if err != nil {
-			return err
+			return finishOutput(err, closer)
 		}
 		pages++
 
@@ -202,7 +214,7 @@ func runSearch(cmd *cobra.Command, args []string) error {
 			sb.WriteByte('\n')
 		}
 		_, err := fmt.Fprint(w, sb.String())
-		return err
+		return finishOutput(err, closer)
 	case "txtar":
 		var sb strings.Builder
 		for _, chunk := range allResults.Results {
@@ -210,8 +222,8 @@ func runSearch(cmd *cobra.Command, args []string) error {
 			sb.WriteString(txtarEntry(name, chunk.Content))
 		}
 		_, err := fmt.Fprint(w, sb.String())
-		return err
+		return finishOutput(err, closer)
 	default:
-		return writeFormatted(w, outputFormat, allResults)
+		return finishOutput(writeFormatted(w, outputFormat, allResults), closer)
 	}
 }

--- a/cmd/search_test.go
+++ b/cmd/search_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"net/http"
+	"strings"
 	"testing"
 
 	dkapi "github.com/apstndb/developerknowledge-go"
@@ -125,5 +126,40 @@ func TestFetchSearchPage_APIError(t *testing.T) {
 	}
 	if ae.Code != 400 {
 		t.Errorf("code = %d, want 400", ae.Code)
+	}
+}
+
+func TestValidateSearchFlags(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		size    int
+		pages   int
+		wantErr string
+	}{
+		{name: "defaults", size: 0, pages: 5},
+		{name: "max_page_size", size: 20, pages: 0},
+		{name: "negative_page_size", size: -1, pages: 5, wantErr: "--page-size"},
+		{name: "too_large_page_size", size: 21, pages: 5, wantErr: "--page-size"},
+		{name: "negative_max_pages", size: 10, pages: -1, wantErr: "--max-pages"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateSearchFlags(tt.size, tt.pages)
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("validateSearchFlags(%d, %d) = %v, want nil", tt.size, tt.pages, err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("validateSearchFlags(%d, %d) = nil, want error containing %q", tt.size, tt.pages, tt.wantErr)
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("error = %q, want substring %q", err, tt.wantErr)
+			}
+		})
 	}
 }

--- a/main.go
+++ b/main.go
@@ -1,7 +1,16 @@
 package main
 
-import "github.com/apstndb/dkcli/cmd"
+import (
+	"context"
+	"os"
+	"os/signal"
+
+	"github.com/apstndb/dkcli/cmd"
+)
 
 func main() {
-	cmd.Execute()
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
+	defer stop()
+
+	cmd.ExecuteContext(ctx)
 }


### PR DESCRIPTION
## Summary
- Add Cobra version output backed by build info / ldflags.
- Propagate SIGINT through `ExecuteContext` using `signal.NotifyContext`.
- Validate global output formats and search pagination flags before API calls.
- Return output file close errors consistently across commands.
- Replace static `fmt.Errorf` calls with `errors.New`.

## Verification
- `go test ./...`
- `go build ./...`
- `go run . --version`
- `git diff --check`

Addresses FEEDBACK.md items #11, #12, #13, #14, #16, and #17.