### PR TITLE
Keep batch output paths inside outdir

### DIFF
--- a/cmd/batchget.go
+++ b/cmd/batchget.go
@@ -111,9 +111,16 @@ func formatExtension(format string) string {
 
 // docFilePath builds the output file path by stripping the "documents/" prefix
 // from the document name and appending the format extension under outDir.
-func docFilePath(outDir, docName, format string) string {
+func docFilePath(outDir, docName, format string) (string, error) {
 	name := strings.TrimPrefix(docName, "documents/")
-	return filepath.Join(outDir, name+formatExtension(format))
+	if name == "" {
+		return "", fmt.Errorf("invalid document name %q", docName)
+	}
+	rel := filepath.FromSlash(name + formatExtension(format))
+	if !filepath.IsLocal(rel) {
+		return "", fmt.Errorf("document name %q escapes output directory", docName)
+	}
+	return filepath.Join(outDir, rel), nil
 }
 
 // formatDocForFile formats a single document for file output.
@@ -165,7 +172,11 @@ func writeBatchOutdir(docs []Document, dir, format string, frontmatter bool) err
 	var writeErrs []error
 	for i := range docs {
 		doc := &docs[i]
-		path := docFilePath(dir, doc.Name, format)
+		path, err := docFilePath(dir, doc.Name, format)
+		if err != nil {
+			writeErrs = append(writeErrs, err)
+			continue
+		}
 
 		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 			writeErrs = append(writeErrs, fmt.Errorf("%s: %w", path, err))

--- a/cmd/batchget_test.go
+++ b/cmd/batchget_test.go
@@ -68,9 +68,32 @@ func TestDocFilePath(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.docName+"_"+tt.format, func(t *testing.T) {
 			t.Parallel()
-			got := docFilePath(tt.dir, tt.docName, tt.format)
+			got, err := docFilePath(tt.dir, tt.docName, tt.format)
+			if err != nil {
+				t.Fatal(err)
+			}
 			if got != tt.want {
 				t.Errorf("docFilePath(%q, %q, %q) = %q, want %q", tt.dir, tt.docName, tt.format, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDocFilePathRejectsEscapes(t *testing.T) {
+	t.Parallel()
+	tests := []string{
+		"",
+		"documents/",
+		"documents/../../outside",
+		"../outside",
+		"/absolute/path",
+	}
+
+	for _, docName := range tests {
+		t.Run(docName, func(t *testing.T) {
+			t.Parallel()
+			if got, err := docFilePath(t.TempDir(), docName, "text"); err == nil {
+				t.Fatalf("docFilePath(%q) = %q, nil; want error", docName, got)
 			}
 		})
 	}
@@ -452,7 +475,10 @@ func TestWriteBatchOutdir(t *testing.T) {
 	}
 
 	for _, doc := range docs {
-		path := docFilePath(dir, doc.Name, "text")
+		path, err := docFilePath(dir, doc.Name, "text")
+		if err != nil {
+			t.Fatal(err)
+		}
 		data, err := os.ReadFile(path)
 		if err != nil {
 			t.Fatalf("failed to read %s: %v", path, err)
@@ -476,7 +502,10 @@ func TestWriteBatchOutdir_JSONFormat(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	path := docFilePath(dir, docs[0].Name, "json")
+	path, err := docFilePath(dir, docs[0].Name, "json")
+	if err != nil {
+		t.Fatal(err)
+	}
 	data, err := os.ReadFile(path)
 	if err != nil {
 		t.Fatalf("failed to read %s: %v", path, err)


### PR DESCRIPTION
## Summary
- Reject empty, absolute, and parent-traversing document names before writing `batch-get --outdir` files.
- Keep generated document paths under the requested output directory.
- Add coverage for valid document paths and rejected escape attempts.

## Verification
- `go test ./cmd -run 'TestDocFilePath|TestWriteBatchOutdir'`
- `go test ./...`
- `go build ./...`
- `git diff --check`

Addresses FEEDBACK.md item #15.