### PR TITLE
Expand CI and dependency maintenance

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+version: 2
+updates:
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      go-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,3 +20,36 @@ jobs:
       - run: go test ./... -race
 
       - run: go vet ./...
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - run: go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.6.2 run --enable-only=govet,ineffassign,unused
+
+  cross-build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - goos: windows
+            goarch: amd64
+          - goos: js
+            goarch: wasm
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - run: go build ./...
+        env:
+          GOOS: ${{ matrix.goos }}
+          GOARCH: ${{ matrix.goarch }}


### PR DESCRIPTION
## Summary
- Add a pinned golangci-lint CI job with a minimal passing linter set.
- Add cross-build coverage for Windows and js/wasm so platform-specific files compile in CI.
- Add Dependabot updates for Go modules and GitHub Actions.

## Verification
- `go test ./...`
- `go build ./...`
- `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.6.2 run --enable-only=govet,ineffassign,unused`
- `env GOCACHE=/tmp/dkcli-go-build GOOS=windows GOARCH=amd64 go build ./...` (passed; sandbox emitted a Go module stat-cache permission warning)
- `env GOCACHE=/tmp/dkcli-go-build GOOS=js GOARCH=wasm go build ./...` (passed; sandbox emitted a Go module stat-cache permission warning)
- `git diff --check`

Addresses FEEDBACK.md items #2, #3, and #4.