### PR TITLE
ci: add govulncheck security lane

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -31,6 +34,19 @@ jobs:
           go-version-file: go.mod
 
       - run: go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.6.2 run --enable-only=govet,ineffassign,unused
+
+  security:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version: "1.25"
+          check-latest: true
+
+      # Keep this inline pin current manually; Dependabot does not update go run pins.
+      - run: go run golang.org/x/vuln/cmd/govulncheck@v1.6.0 ./...
 
   cross-build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- restrict the CI workflow to read-only repository contents
- add a dedicated security job that runs `govulncheck` v1.6.0
- use the latest Go 1.25 patch for the vulnerability scan to avoid stale standard-library findings

## Why

The repository did not run vulnerability analysis in CI. Adding the scan before the next release ensures dependency and reachable standard-library vulnerabilities are checked on every push and pull request.

## Validation

- YAML syntax validation with Ruby Psych
- `go build ./...`
- `go test ./... -race`
- `go vet ./...`
- `GOOS=windows GOARCH=amd64 go build ./...`
- `GOOS=js GOARCH=wasm go build ./...`
- `go run golang.org/x/vuln/cmd/govulncheck@v1.6.0 ./...`
- `git diff --check`
