### PR TITLE
deps: migrate Developer Knowledge client to v0.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ dkcli get https://docs.cloud.google.com/storage/docs/creating-buckets
 ```
 
 If you already know the document URL, skip `search` and go straight to `get` or `batch-get`.
+Invalid URL-like document names are rejected locally before authentication or an API request.
 
 ### Get multiple documents
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -111,6 +111,8 @@ The document name is the URL path without `https://`. Full URLs also work:
 dkcli get https://docs.cloud.google.com/storage/docs/creating-buckets
 ```
 
+Invalid URL-like document names are rejected locally before authentication or an API request.
+
 ### When you already know the document
 
 If you can reasonably guess the URL of the documentation page (e.g., the user gave you a link, or you know the path pattern), skip search and go straight to `dkcli get` (or `dkcli batch-get` for multiple pages). This saves a round trip.

--- a/cmd/answerquery.go
+++ b/cmd/answerquery.go
@@ -128,11 +128,10 @@ func formatAnswerText(answer *Answer) string {
 }
 
 func runAnswerQuery(cmd *cobra.Command, args []string) error {
-	client, err := newAPIClient(cmd.Context(), authPreferAPIKey)
+	client, err := newAPIClientForBaseURL(cmd.Context(), authPreferAPIKey, answerQueryBaseURL)
 	if err != nil {
 		return err
 	}
-	client.baseURL = answerQueryBaseURL
 
 	resp, err := client.answerQuery(strings.Join(args, " "))
 	if err != nil {

--- a/cmd/batchget.go
+++ b/cmd/batchget.go
@@ -13,8 +13,6 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-const batchGetMaxDocs = 20
-
 var (
 	outDir           string
 	batchFrontmatter bool
@@ -280,6 +278,9 @@ func runBatchGet(cmd *cobra.Command, args []string) error {
 	names := make([]string, len(args))
 	for i, arg := range args {
 		names[i] = normalizeDocName(arg)
+		if names[i] == "" {
+			return fmt.Errorf("invalid document name at argument %d", i+1)
+		}
 	}
 
 	client, err := newAPIClient(cmd.Context(), authPreferAPIKey)
@@ -289,11 +290,11 @@ func runBatchGet(cmd *cobra.Command, args []string) error {
 
 	var docs []Document
 	var docErrs []error
-	for i := 0; i < len(names); i += batchGetMaxDocs {
-		end := min(i+batchGetMaxDocs, len(names))
+	for i := 0; i < len(names); i += dkapi.MaxBatchGetDocuments {
+		end := min(i+dkapi.MaxBatchGetDocuments, len(names))
 		chunk := names[i:end]
 
-		if verbose && len(names) > batchGetMaxDocs {
+		if verbose && len(names) > dkapi.MaxBatchGetDocuments {
 			fmt.Fprintf(os.Stderr, "Fetching chunk %d-%d of %d documents...\n", i+1, end, len(names))
 		}
 

--- a/cmd/batchget_test.go
+++ b/cmd/batchget_test.go
@@ -14,6 +14,7 @@ import (
 
 	dkapi "github.com/apstndb/developerknowledge-go"
 	"github.com/spf13/cobra"
+	"golang.org/x/oauth2"
 	"golang.org/x/time/rate"
 )
 
@@ -28,6 +29,32 @@ func newTestClient(t *testing.T, handler http.Handler) *apiClient {
 		client:  srv.Client(),
 		limiter: rate.NewLimiter(rate.Inf, 1),
 		verbose: false,
+	}
+}
+
+func TestRunBatchGetRejectsInvalidDocumentNameBeforeAuthentication(t *testing.T) {
+	t.Setenv("DEVELOPERKNOWLEDGE_API_KEY", "")
+	t.Setenv("GOOGLE_API_KEY", "")
+
+	origTokenSource := defaultTokenSource
+	called := false
+	defaultTokenSource = func(context.Context, ...string) (oauth2.TokenSource, error) {
+		called = true
+		return nil, errors.New("authentication should not run")
+	}
+	t.Cleanup(func() { defaultTokenSource = origTokenSource })
+
+	cmd := &cobra.Command{}
+	cmd.SetContext(context.Background())
+	err := runBatchGet(cmd, []string{"documents/example.com/good", "https://user:secret@example.com/document"})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if err.Error() != "invalid document name at argument 2" {
+		t.Fatalf("error = %q, want invalid input without the raw URL", err)
+	}
+	if called {
+		t.Fatal("authentication ran for an invalid document name")
 	}
 }
 
@@ -301,16 +328,16 @@ func TestRunBatchGetPrintsSummaryOnlyForTextOutput(t *testing.T) {
 func TestFetchBatchBisect(t *testing.T) {
 	t.Parallel()
 
-	// Simulate: batch containing "bad" fails with 400, others succeed.
+	// Simulate: batch containing "bad" fails with 404, others succeed.
 	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		names := r.URL.Query()["names"]
 		for _, n := range names {
 			if n == "documents/bad" {
 				w.Header().Set("Content-Type", "application/json")
-				w.WriteHeader(http.StatusBadRequest)
+				w.WriteHeader(http.StatusNotFound)
 				json.NewEncoder(w).Encode(map[string]any{
 					"error": map[string]any{
-						"code":    400,
+						"code":    404,
 						"message": "not found",
 						"status":  "NOT_FOUND",
 					},

--- a/cmd/createapikey.go
+++ b/cmd/createapikey.go
@@ -198,7 +198,7 @@ func newAPIKeysClient(ctx context.Context) (*http.Client, error) {
 	// Charge quota/billing to the configured ADC quota project, matching the
 	// rest of the CLI, rather than implicitly using the target project passed
 	// to --project.
-	return newADCHTTPClient(ctx, authRequireADC, 0)
+	return newADCHTTPClient(ctx, authRequireADC, 0, apiKeysBaseURL)
 }
 
 func doAPIKeysRequest(ctx context.Context, client *http.Client, method, url string, body []byte, contentType string) ([]byte, error) {

--- a/cmd/createapikey_test.go
+++ b/cmd/createapikey_test.go
@@ -265,17 +265,20 @@ func TestNewAPIKeysClient_UsesResolvedQuotaProject(t *testing.T) {
 	}
 	t.Cleanup(func() { defaultTokenSource = orig })
 
-	client, err := newAPIKeysClient(context.Background())
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	var gotQuota string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		gotQuota = r.Header.Get("x-goog-user-project")
 		w.WriteHeader(http.StatusOK)
 	}))
 	t.Cleanup(srv.Close)
+	origBaseURL := apiKeysBaseURL
+	apiKeysBaseURL = srv.URL
+	t.Cleanup(func() { apiKeysBaseURL = origBaseURL })
+
+	client, err := newAPIKeysClient(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	resp, err := client.Get(srv.URL)
 	if err != nil {
@@ -292,7 +295,13 @@ func TestNewAPIKeysClient_FailsWithoutQuotaProjectForUserADC(t *testing.T) {
 
 	dir := t.TempDir()
 	path := filepath.Join(dir, "adc.json")
-	data, err := json.Marshal(map[string]string{"type": "authorized_user"})
+	data, err := json.Marshal(map[string]string{
+		"type":          "authorized_user",
+		"client_id":     "test-client-id",
+		"client_secret": "test-client-secret",
+		"refresh_token": "test-refresh-token",
+		"token_uri":     "https://oauth2.googleapis.com/token",
+	})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -305,9 +314,7 @@ func TestNewAPIKeysClient_FailsWithoutQuotaProjectForUserADC(t *testing.T) {
 	t.Cleanup(func() { adcCredentialsPath = origPath })
 
 	origTokenSource := defaultTokenSource
-	defaultTokenSource = func(ctx context.Context, scopes ...string) (oauth2.TokenSource, error) {
-		return oauth2.StaticTokenSource(&oauth2.Token{AccessToken: "test-token"}), nil
-	}
+	defaultTokenSource = nil
 	t.Cleanup(func() { defaultTokenSource = origTokenSource })
 
 	_, err = newAPIKeysClient(context.Background())

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -89,12 +89,15 @@ func runGet(cmd *cobra.Command, args []string) error {
 		return errors.New(getFrontmatterTextFormatError)
 	}
 
+	name := normalizeDocName(args[0])
+	if name == "" {
+		return errors.New("invalid document name")
+	}
+
 	client, err := newAPIClient(cmd.Context(), authPreferAPIKey)
 	if err != nil {
 		return err
 	}
-
-	name := normalizeDocName(args[0])
 	body, err := client.fetchDocument(name)
 	if err != nil {
 		return err

--- a/cmd/get_test.go
+++ b/cmd/get_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
@@ -11,6 +12,7 @@ import (
 	"testing"
 
 	"github.com/spf13/cobra"
+	"golang.org/x/oauth2"
 	"golang.org/x/time/rate"
 )
 
@@ -32,6 +34,32 @@ func TestNormalizeDocName(t *testing.T) {
 				t.Errorf("normalizeDocName(%q) = %q, want %q", tt.input, got, tt.want)
 			}
 		})
+	}
+}
+
+func TestRunGetRejectsInvalidDocumentNameBeforeAuthentication(t *testing.T) {
+	t.Setenv("DEVELOPERKNOWLEDGE_API_KEY", "")
+	t.Setenv("GOOGLE_API_KEY", "")
+
+	origTokenSource := defaultTokenSource
+	called := false
+	defaultTokenSource = func(context.Context, ...string) (oauth2.TokenSource, error) {
+		called = true
+		return nil, errors.New("authentication should not run")
+	}
+	t.Cleanup(func() { defaultTokenSource = origTokenSource })
+
+	cmd := &cobra.Command{}
+	cmd.SetContext(context.Background())
+	err := runGet(cmd, []string{"https://user:secret@example.com/document"})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if err.Error() != "invalid document name" {
+		t.Fatalf("error = %q, want %q", err, "invalid document name")
+	}
+	if called {
+		t.Fatal("authentication ran for an invalid document name")
 	}
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -14,7 +14,6 @@ import (
 
 	dkapi "github.com/apstndb/developerknowledge-go"
 	"github.com/spf13/cobra"
-	"golang.org/x/oauth2"
 	"golang.org/x/time/rate"
 	"gopkg.in/yaml.v3"
 )
@@ -31,7 +30,7 @@ var (
 var version = "dev"
 
 var (
-	searchBaseURL = "https://developerknowledge.googleapis.com/v1"
+	searchBaseURL = dkapi.DefaultV1BaseURL
 	// Workaround: answerQuery is still documented and served on v1alpha.
 	answerQueryBaseURL = "https://developerknowledge.googleapis.com/v1alpha"
 )
@@ -45,11 +44,12 @@ const (
 	authRequireADC   = dkapi.AuthRequireADC
 )
 
-var defaultTokenSource = func(ctx context.Context, scopes ...string) (oauth2.TokenSource, error) {
-	return dkapi.DefaultTokenSource(ctx, scopes...)
-}
+// Nil defaults preserve dkapi's ADC discovery, including credentials-file
+// metadata such as quota_project_id and metadata-server fallback. Tests may
+// override either seam for deterministic authentication behavior.
+var defaultTokenSource dkapi.TokenSourceFunc
 
-var adcCredentialsPath = dkapi.DefaultCredentialsPath
+var adcCredentialsPath func() string
 
 var rootCmd = &cobra.Command{
 	Use:     "dkcli",
@@ -107,41 +107,46 @@ type apiClient struct {
 	verbose bool
 }
 
-func apiKeyFromEnv() string {
-	return dkapi.APIKeyFromEnv()
+func newADCHTTPClient(ctx context.Context, mode authMode, timeout time.Duration, baseURL string) (*http.Client, error) {
+	return dkapi.NewADCHTTPClient(ctx, authConfig(mode, timeout, baseURL))
 }
 
-func newADCHTTPClient(ctx context.Context, mode authMode, timeout time.Duration) (*http.Client, error) {
-	return dkapi.NewADCHTTPClient(ctx, dkapi.AuthConfig{
-		Mode:            mode,
-		Timeout:         timeout,
-		TokenSource:     defaultTokenSource,
-		CredentialsPath: adcCredentialsPath,
-	})
+func authConfig(mode authMode, timeout time.Duration, baseURL string) dkapi.AuthConfig {
+	cfg := dkapi.AuthConfig{
+		Mode:          mode,
+		Timeout:       timeout,
+		AllowedOrigin: baseURL,
+	}
+	if defaultTokenSource != nil {
+		cfg.TokenSource = defaultTokenSource
+	}
+	if adcCredentialsPath != nil {
+		cfg.CredentialsPath = adcCredentialsPath
+	}
+	return cfg
 }
 
 // newAPIClient creates an apiClient using the global defaults.
 func newAPIClient(ctx context.Context, mode authMode) (*apiClient, error) {
+	return newAPIClientForBaseURL(ctx, mode, searchBaseURL)
+}
+
+// newAPIClientForBaseURL creates an apiClient whose requests and authentication
+// origin guard use the same API base URL.
+func newAPIClientForBaseURL(ctx context.Context, mode authMode, baseURL string) (*apiClient, error) {
 	client := &apiClient{
-		baseURL: searchBaseURL,
+		baseURL: baseURL,
 		ctx:     ctx,
 		limiter: apiLimiter,
 		verbose: verbose,
 	}
 
-	if mode == authPreferAPIKey {
-		if apiKey := apiKeyFromEnv(); apiKey != "" {
-			client.apiKey = apiKey
-			client.client = &http.Client{Timeout: defaultHTTPTimeout}
-			return client, nil
-		}
-	}
-
-	var err error
-	client.client, err = newADCHTTPClient(ctx, mode, defaultHTTPTimeout)
+	httpClient, apiKey, err := dkapi.NewAuthenticatedHTTPClient(ctx, authConfig(mode, defaultHTTPTimeout, baseURL))
 	if err != nil {
 		return nil, err
 	}
+	client.apiKey = apiKey
+	client.client = httpClient
 	return client, nil
 }
 

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -140,7 +140,7 @@ func TestNewAPIClient_SetsQuotaProjectHeader(t *testing.T) {
 	}))
 	t.Cleanup(srv.Close)
 
-	client, err := newAPIClient(context.Background(), authPreferAPIKey)
+	client, err := newAPIClientForBaseURL(context.Background(), authPreferAPIKey, srv.URL)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -161,7 +161,13 @@ func TestNewAPIClient_FailsFastWithoutQuotaProjectForUserADC(t *testing.T) {
 
 	dir := t.TempDir()
 	path := filepath.Join(dir, "adc.json")
-	data, err := json.Marshal(map[string]string{"type": "authorized_user"})
+	data, err := json.Marshal(map[string]string{
+		"type":          "authorized_user",
+		"client_id":     "test-client-id",
+		"client_secret": "test-client-secret",
+		"refresh_token": "test-refresh-token",
+		"token_uri":     "https://oauth2.googleapis.com/token",
+	})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -174,9 +180,7 @@ func TestNewAPIClient_FailsFastWithoutQuotaProjectForUserADC(t *testing.T) {
 	t.Cleanup(func() { adcCredentialsPath = origPath })
 
 	origTokenSource := defaultTokenSource
-	defaultTokenSource = func(ctx context.Context, scopes ...string) (oauth2.TokenSource, error) {
-		return oauth2.StaticTokenSource(&oauth2.Token{AccessToken: "test-token"}), nil
-	}
+	defaultTokenSource = nil
 	t.Cleanup(func() { defaultTokenSource = origTokenSource })
 
 	_, err = newAPIClient(context.Background(), authPreferAPIKey)
@@ -188,12 +192,77 @@ func TestNewAPIClient_FailsFastWithoutQuotaProjectForUserADC(t *testing.T) {
 	}
 }
 
+func TestNewAPIClient_ADCFetchUsesQuotaProjectAndAllowedOrigin(t *testing.T) {
+	t.Setenv("DEVELOPERKNOWLEDGE_API_KEY", "")
+	t.Setenv("GOOGLE_API_KEY", "")
+	t.Setenv("GOOGLE_CLOUD_QUOTA_PROJECT", "")
+
+	var tokenMethod, authorization, quotaProject string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/token":
+			tokenMethod = r.Method
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, `{"access_token":"test-token","token_type":"Bearer","expires_in":3600}`)
+		case "/v1/documents/example.com/page":
+			authorization = r.Header.Get("Authorization")
+			quotaProject = r.Header.Get("x-goog-user-project")
+			_, _ = io.WriteString(w, `{}`)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	path := filepath.Join(t.TempDir(), "adc.json")
+	data, err := json.Marshal(map[string]string{
+		"type":             "authorized_user",
+		"client_id":        "test-client-id",
+		"client_secret":    "test-client-secret",
+		"refresh_token":    "test-refresh-token",
+		"token_uri":        srv.URL + "/token",
+		"quota_project_id": "quota-project",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	origPath := adcCredentialsPath
+	adcCredentialsPath = func() string { return path }
+	t.Cleanup(func() { adcCredentialsPath = origPath })
+
+	origTokenSource := defaultTokenSource
+	defaultTokenSource = nil
+	t.Cleanup(func() { defaultTokenSource = origTokenSource })
+
+	client, err := newAPIClientForBaseURL(context.Background(), authPreferAPIKey, srv.URL+"/v1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := client.fetchDocument("documents/example.com/page"); err != nil {
+		t.Fatal(err)
+	}
+	if tokenMethod != http.MethodPost {
+		t.Fatalf("token request method = %s, want POST", tokenMethod)
+	}
+	if authorization != "Bearer test-token" {
+		t.Fatalf("authorization = %q, want bearer token", authorization)
+	}
+	if quotaProject != "quota-project" {
+		t.Fatalf("x-goog-user-project = %q, want %q", quotaProject, "quota-project")
+	}
+}
+
 func TestAPIClient_DoRequestHonorsCanceledContextWhileWaiting(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
 	called := false
 	client := &apiClient{
+		baseURL: "https://example.com",
 		client: &http.Client{
 			Transport: roundTripperFunc(func(req *http.Request) (*http.Response, error) {
 				called = true
@@ -223,6 +292,7 @@ func TestAPIClient_DoRequestUsesRequestContext(t *testing.T) {
 
 	done := make(chan error, 1)
 	client := &apiClient{
+		baseURL: "https://example.com",
 		client: &http.Client{
 			Transport: roundTripperFunc(func(req *http.Request) (*http.Response, error) {
 				<-req.Context().Done()
@@ -256,6 +326,7 @@ func TestAPIClient_DoRequestCancelsRetryBackoff(t *testing.T) {
 
 	attempts := 0
 	client := &apiClient{
+		baseURL: "https://example.com",
 		client: &http.Client{
 			Transport: roundTripperFunc(func(req *http.Request) (*http.Response, error) {
 				attempts++

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/apstndb/dkcli
 go 1.25.0
 
 require (
-	github.com/apstndb/developerknowledge-go v0.2.0
+	github.com/apstndb/developerknowledge-go v0.3.0
 	github.com/spf13/cobra v1.10.2
 	golang.org/x/oauth2 v0.36.0
 	golang.org/x/time v0.15.0

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 cloud.google.com/go/compute/metadata v0.3.0 h1:Tz+eQXMEqDIKRsmY3cHTL6FVaynIjX2QxYC4trgAKZc=
 cloud.google.com/go/compute/metadata v0.3.0/go.mod h1:zFmK7XCadkQkj6TtorcaGlCW1hT1fIilQDwofLpJ20k=
-github.com/apstndb/developerknowledge-go v0.2.0 h1:Hvf17+JZG+n1f7UPcQRAryrtlA31oMSfJtuo53DOEe4=
-github.com/apstndb/developerknowledge-go v0.2.0/go.mod h1:SkrYUXrudPdwg//GnGSnLsjYilMI+9n2+TGUuHo/CcE=
+github.com/apstndb/developerknowledge-go v0.3.0 h1:oNzXjK31Gp3o97Z1qFu22zy4GIv+BSrJo00w2XgIqDo=
+github.com/apstndb/developerknowledge-go v0.3.0/go.mod h1:SkrYUXrudPdwg//GnGSnLsjYilMI+9n2+TGUuHo/CcE=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=


### PR DESCRIPTION
## Summary

- upgrade `developerknowledge-go` from v0.2.0 to v0.3.0
- bind authenticated clients to the API origin selected by each command while preserving ADC quota-project metadata
- reject invalid document names before authentication and adopt the library's batch-size and error-classification contracts
- keep README and skill guidance aligned with the stricter local validation

## Validation

- `go mod verify`
- `go build ./...`
- `go test ./...`
- `go test -race ./...`
- `go vet ./...`
- `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.6.2 run --enable-only=govet,ineffassign,unused`
- `go run golang.org/x/vuln/cmd/govulncheck@v1.6.0 ./...`
- `GOOS=windows GOARCH=amd64 go build ./...`
- `GOOS=js GOARCH=wasm go build ./...`
- `git diff --check`
