### PR TITLE
feat: align with GA Developer Knowledge API

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,7 @@
 - `cmd/root.go` centralizes shared HTTP behavior: global output flags, auth selection, rate limiting, retries, and structured output helpers.
 - `search` targets the GA `v1` REST surface.
 - `get` and `batch-get` target the GA `v1` REST surface.
-- `answer-query` currently uses `v1alpha` because that is the documented live endpoint.
+- `answer-query` targets the GA `v1:answerQuery` endpoint.
 - `create-api-key` uses ADC against the API Keys API, then fetches the key string from the follow-up endpoint.
 - Tests live beside the command code in `cmd/` and mostly use `httptest`; `newTestClient` in `cmd/batchget_test.go` is the shared fixture for document API tests.
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@ go install github.com/apstndb/dkcli@latest
 
 ## Authentication
 
-Developer Knowledge API commands use Application Default Credentials (ADC) by default, except `create-api-key` which always requires ADC.
+Developer Knowledge API commands use `DEVELOPERKNOWLEDGE_API_KEY` or
+`GOOGLE_API_KEY` when set, and otherwise fall back to Application Default
+Credentials (ADC). The `create-api-key` command always requires ADC.
 
 Set up ADC:
 
@@ -20,7 +22,7 @@ gcloud auth application-default login
 
 When using local ADC, the Developer Knowledge API also requires a quota project. dkcli reads that from `GOOGLE_CLOUD_QUOTA_PROJECT` or `quota_project_id` in the ADC file. The standard way to set that up is `gcloud auth application-default set-quota-project <project-id>`.
 
-If you prefer to use an API key instead of ADC, set one of the following environment variables:
+To use an API key, set one of the following environment variables:
 
 ```
 export DEVELOPERKNOWLEDGE_API_KEY=<your-key>
@@ -58,6 +60,9 @@ Invalid URL-like document names are rejected locally before authentication or an
 
 ### Get multiple documents
 
+The live API accepts up to 20 document names per batch request. `batch-get`
+automatically chunks larger input lists into multiple requests.
+
 ```
 dkcli batch-get docs.cloud.google.com/path/to/doc1 docs.cloud.google.com/path/to/doc2
 
@@ -82,7 +87,8 @@ dkcli create-api-key
 
 ### Answer a grounded query
 
-Uses the `v1alpha:answerQuery` endpoint. It works with an API key, or with ADC if a quota project is available.
+Uses the GA `v1:answerQuery` endpoint. It works with an API key, or with ADC if
+a quota project is available.
 
 ```
 dkcli answer-query "How do I create a Cloud Storage bucket?"
@@ -92,9 +98,7 @@ The text output prints the generated answer followed by source references when
 the API returns them. Structured formats include the full `answer` payload,
 including citation spans and referenced document chunks.
 
-**Note:** This endpoint is a preview surface and is currently limited to 50
-requests per day per project. For full-document verification, prefer the
-`search` + `get` workflow.
+For full-document verification, prefer the `search` + `get` workflow.
 
 ## Global flags
 
@@ -110,7 +114,7 @@ requests per day per project. For full-document verification, prefer the
 
 | Flag | Description |
 |------|-------------|
-| `--page-size` | Max results to return (max: 20, default is set by the API) |
+| `--page-size` | Max results to return (max: 100, default is set by the API) |
 | `--page-token` | Pagination token from previous response |
 | `--auto-paging`, `-a` | Automatically fetch subsequent pages |
 | `--max-pages` | Max pages to fetch with `--auto-paging` (default: 5, 0 for unlimited) |

--- a/SKILL.md
+++ b/SKILL.md
@@ -92,7 +92,7 @@ dkcli search --filter 'data_source = "docs.cloud.google.com"' "BigQuery"
 
 Once you know the document name(s) from search results, retrieve the full page(s).
 When search returns multiple relevant results, use `batch-get` to fetch them all.
-The API limits each call to 20 documents; `batch-get` automatically chunks larger
+The live API limits each call to 20 documents; `batch-get` automatically chunks larger
 lists into multiple calls:
 
 ```bash
@@ -105,7 +105,9 @@ If you only need a single document, `get` works the same way:
 dkcli get docs.cloud.google.com/storage/docs/creating-buckets
 ```
 
-The document name is the URL path without `https://`. Full URLs also work:
+The normalized document name includes the URL host and path without the scheme
+(for example, `docs.cloud.google.com/storage/docs/creating-buckets`). Full URLs
+also work:
 
 ```bash
 dkcli get https://docs.cloud.google.com/storage/docs/creating-buckets
@@ -154,9 +156,14 @@ For a quick generated answer instead of raw document content, use:
 dkcli answer-query "How do I create a Cloud Storage bucket?"
 ```
 
-This command calls the `v1alpha:answerQuery` endpoint. It works with an API key, or with ADC if a quota project is available.
+This command calls the GA `v1:answerQuery` endpoint. It works with an API key,
+or with ADC if a quota project is available.
 
-**Caveat:** The `answer-query` endpoint returns generated text with citations and references to source document chunks, but it is still a preview endpoint and is currently limited to 50 requests per day per project. For authoritative or full-context verification, **prefer the `search` + `get` workflow**. Use `answer-query` when you need a quick grounded overview, then fetch referenced documents before making or publishing a factual claim.
+**Caveat:** The `answer-query` endpoint returns generated text with citations
+and references to source document chunks. For authoritative or full-context
+verification, **prefer the `search` + `get` workflow**. Use `answer-query` when
+you need a quick grounded overview, then fetch referenced documents before
+making or publishing a factual claim.
 
 ### Evidence-grade research
 
@@ -218,11 +225,15 @@ dkcli batch-get -f txtar docs.cloud.google.com/doc1 docs.cloud.google.com/doc2  
 
 ## Error handling
 
-Developer Knowledge API commands use Application Default Credentials (ADC) by default, except `create-api-key` which always requires ADC. If an API key environment variable is set (`DEVELOPERKNOWLEDGE_API_KEY` or `GOOGLE_API_KEY`), dkcli uses it instead of ADC.
+Developer Knowledge API commands use an API key when
+`DEVELOPERKNOWLEDGE_API_KEY` or `GOOGLE_API_KEY` is set; otherwise dkcli falls
+back to Application Default Credentials (ADC). The `create-api-key` command
+always requires ADC.
 
 When using local ADC, the Developer Knowledge API also requires a quota project. dkcli resolves that from `GOOGLE_CLOUD_QUOTA_PROJECT` or `quota_project_id` in the ADC file. The standard way to set that up is `gcloud auth application-default set-quota-project <project-id>`.
 
-If dkcli fails because ADC is not available, suggest:
+If neither API key environment variable is set and dkcli fails because ADC is
+not available, suggest:
 
 ```bash
 # Option 1: set up ADC (recommended)
@@ -242,7 +253,7 @@ If the user already has an API key and prefers to use it, they just need to set 
 export DEVELOPERKNOWLEDGE_API_KEY=<key>
 ```
 
-Note: `get` and `batch-get` use the GA `v1` document endpoints. `answer-query` still uses `v1alpha:answerQuery`.
+Note: `get`, `batch-get`, and `answer-query` use GA `v1` endpoints.
 
 ## Command reference
 
@@ -259,7 +270,7 @@ Note: `get` and `batch-get` use the GA `v1` document endpoints. `answer-query` s
 |---|---|
 | `-f json\|yaml\|jsonl\|txtar` | Output format (default: text) |
 | `-o <file>` | Write to file |
-| `--page-size N` | Results per page for search (max 20) |
+| `--page-size N` | Results per page for search (max 100) |
 | `--max-pages N` | Max pages with `-a` (default 5) |
 | `--filter <expr>` | Filter search results by document metadata |
 | `--outdir <dir>` | Write each doc to separate files (batch-get) |

--- a/cmd/answerquery.go
+++ b/cmd/answerquery.go
@@ -13,10 +13,9 @@ var answerQueryCmd = &cobra.Command{
 	Short: "Answer a query using grounded generation",
 	Long: `Answer a query using the Developer Knowledge grounded generation API.
 
-This endpoint is currently exposed as v1alpha and returns generated text with
-citations and references to source document chunks. Text output prints the
-answer followed by source references; structured output includes the full
-answer payload.
+This GA endpoint returns generated text with citations and references to source
+document chunks. Text output prints the answer followed by source references;
+structured output includes the full answer payload.
 
 If an API key is configured, dkcli uses it. Otherwise it falls back to ADC.`,
 	Args: cobra.MinimumNArgs(1),

--- a/cmd/answerquery_test.go
+++ b/cmd/answerquery_test.go
@@ -17,7 +17,7 @@ import (
 
 func TestAnswerQuery(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/v1alpha:answerQuery" {
+		if r.URL.Path != "/v1:answerQuery" {
 			http.Error(w, "not found", http.StatusNotFound)
 			return
 		}
@@ -59,7 +59,7 @@ func TestAnswerQuery(t *testing.T) {
 	t.Cleanup(srv.Close)
 
 	client := &apiClient{
-		baseURL: srv.URL + "/v1alpha",
+		baseURL: srv.URL + "/v1",
 		client:  srv.Client(),
 		limiter: rate.NewLimiter(rate.Inf, 1),
 	}
@@ -91,7 +91,7 @@ func TestAnswerQuery(t *testing.T) {
 
 func TestRunAnswerQueryTextIncludesReferences(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/v1alpha:answerQuery" {
+		if r.URL.Path != "/v1:answerQuery" {
 			http.Error(w, "not found", http.StatusNotFound)
 			return
 		}
@@ -129,7 +129,7 @@ func TestRunAnswerQueryTextIncludesReferences(t *testing.T) {
 		outputFile = origOutputFile
 	})
 
-	answerQueryBaseURL = srv.URL + "/v1alpha"
+	answerQueryBaseURL = srv.URL + "/v1"
 	apiLimiter = rate.NewLimiter(rate.Inf, 1)
 	outputFormat = "text"
 	outputFile = filepath.Join(t.TempDir(), "answer.txt")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -30,9 +30,8 @@ var (
 var version = "dev"
 
 var (
-	searchBaseURL = dkapi.DefaultV1BaseURL
-	// Workaround: answerQuery is still documented and served on v1alpha.
-	answerQueryBaseURL = "https://developerknowledge.googleapis.com/v1alpha"
+	searchBaseURL      = dkapi.DefaultV1BaseURL
+	answerQueryBaseURL = dkapi.DefaultV1BaseURL
 )
 
 const defaultHTTPTimeout = dkapi.DefaultHTTPTimeout

--- a/cmd/search.go
+++ b/cmd/search.go
@@ -22,6 +22,8 @@ var (
 	searchFilter string
 )
 
+const maxSearchPageSize = 100
+
 var searchCmd = &cobra.Command{
 	Use:   "search <query>...",
 	Short: "Search developer documentation chunks",
@@ -33,7 +35,7 @@ var searchCmd = &cobra.Command{
 }
 
 func init() {
-	searchCmd.Flags().IntVar(&pageSize, "page-size", 0, "max results to return (max: 20, default is set by the API)")
+	searchCmd.Flags().IntVar(&pageSize, "page-size", 0, "max results to return (max: 100, default is set by the API)")
 	searchCmd.Flags().StringVar(&pageToken, "page-token", "", "pagination token from previous response")
 	searchCmd.Flags().BoolVarP(&autoPaging, "auto-paging", "a", false, "automatically fetch subsequent pages")
 	searchCmd.Flags().IntVar(&maxPages, "max-pages", 5, "max pages to fetch with --auto-paging (0 for unlimited)")
@@ -121,8 +123,8 @@ func (c *apiClient) fetchSearchPage(query string, size int, token, filter string
 }
 
 func validateSearchFlags(size, pages int) error {
-	if size < 0 || size > 20 {
-		return fmt.Errorf("--page-size must be between 0 and 20")
+	if size < 0 || size > maxSearchPageSize {
+		return fmt.Errorf("--page-size must be between 0 and %d", maxSearchPageSize)
 	}
 	if pages < 0 {
 		return fmt.Errorf("--max-pages must be greater than or equal to 0")
@@ -138,7 +140,7 @@ func runSearch(cmd *cobra.Command, args []string) error {
 
 	// When auto-paging, default to max page size to minimize requests.
 	if autoPaging && !cmd.Flags().Changed("page-size") {
-		pageSize = 20
+		pageSize = maxSearchPageSize
 	}
 
 	query := strings.Join(args, " ")

--- a/cmd/search_test.go
+++ b/cmd/search_test.go
@@ -139,9 +139,10 @@ func TestValidateSearchFlags(t *testing.T) {
 		wantErr string
 	}{
 		{name: "defaults", size: 0, pages: 5},
-		{name: "max_page_size", size: 20, pages: 0},
+		{name: "max_page_size", size: 100, pages: 0},
+		{name: "previous_page_size_limit", size: 21, pages: 5},
 		{name: "negative_page_size", size: -1, pages: 5, wantErr: "--page-size"},
-		{name: "too_large_page_size", size: 21, pages: 5, wantErr: "--page-size"},
+		{name: "too_large_page_size", size: 101, pages: 5, wantErr: "--page-size"},
 		{name: "negative_max_pages", size: 10, pages: -1, wantErr: "--max-pages"},
 	}
 


### PR DESCRIPTION
## Summary

- raise the `search` page-size limit from 20 to the GA maximum of 100
- move `answer-query` from the v1alpha endpoint to the GA v1 endpoint
- update command help, README guidance, and the bundled skill to match current API behavior

## Verification

- `go mod verify`
- `go build ./...`
- `go test ./... -race`
- `go vet ./...`
- pinned `golangci-lint`
- pinned `govulncheck`
- Windows amd64 and js/wasm cross-builds

## Compatibility

The CLI commands, flags, and output shape are unchanged. The page-size change only accepts values that were previously rejected, so this is suitable for a patch release.
